### PR TITLE
Decoupling from API with updates

### DIFF
--- a/src/crons/update.php
+++ b/src/crons/update.php
@@ -8,10 +8,7 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'xc_vm') {
             }
 
             require str_replace('\\', '/', dirname($argv[0])) . '/../www/init.php';
-
-            $ApiIP = json_decode(file_get_contents("https://raw.githubusercontent.com/Vateron-Media/XC_VM_Update/refs/heads/main/api_server.json"), true);
-            $ApiURL = 'http://' . $ApiIP['ip'] . '/api/v1/check_updates?version=' . XC_VM_VERSION;
-            $rUpdate = json_decode(file_get_contents($ApiURL), true);
+            $rUpdate = $gitRelease->getUpdate(XC_VM_VERSION);
 
             if (is_array($rUpdate) && $rUpdate['version'] && (0 < version_compare($rUpdate['version'], XC_VM_VERSION) || version_compare($rUpdate['version'], XC_VM_VERSION) == 0)) {
                 echo 'Update is available!' . "\n";

--- a/src/includes/libs/GithubReleases.php
+++ b/src/includes/libs/GithubReleases.php
@@ -1,0 +1,406 @@
+<?php
+
+class GitHubReleases {
+    private $owner;
+    private $repo;
+    private $api_url;
+    private $headers;
+    private $timeout = 5; // Request timeout in seconds
+    private $cache_file = '/home/xc_vm/tmp/gitapi'; // Cache file path
+    private $hash_file = 'hashes.md5';
+    private $cache_ttl = 1800; // Cache TTL in seconds (30 minutes)
+
+    /**
+     * Initialize a GitHubReleases instance for accessing release data of a GitHub repository.
+     *
+     * @param string $owner Repository owner (e.g., "Vateron-Media").
+     * @param string $repo Repository name (e.g., "XC_VM").
+     * @param string|null $token GitHub API token for authentication (optional).
+     */
+    public function __construct(string $owner, string $repo, ?string $token = null) {
+        $this->owner = $owner;
+        $this->repo = $repo;
+        $this->api_url = "https://api.github.com/repos/{$owner}/{$repo}/releases";
+        $this->headers = $token ? [
+            "Authorization: Bearer {$token}",
+            'Accept: application/vnd.github+json',
+            'X-GitHub-Api-Version: 2022-11-28'
+        ] : [];
+    }
+
+    /**
+     * Clear the cached release data by deleting the cache file.
+     */
+    public function clearCache(): void {
+        if (file_exists($this->cache_file)) {
+            unlink($this->cache_file);
+            error_log("Cache cleared for {$this->owner}/{$this->repo} by deleting {$this->cache_file}");
+        }
+    }
+
+    /**
+     * Check if the cache file is still valid based on TTL.
+     *
+     * @return bool True if cache is valid, False otherwise.
+     */
+    private function isCacheValid(): bool {
+        if (!file_exists($this->cache_file)) {
+            return false;
+        }
+        $cache_timestamp = filemtime($this->cache_file);
+        return (time() - $cache_timestamp) < $this->cache_ttl;
+    }
+
+    /**
+     * Load cache from file.
+     *
+     * @return array|null The cached data, or null if the file doesn't exist or is invalid.
+     */
+    private function loadCache(): ?array {
+        if (!file_exists($this->cache_file)) {
+            return null;
+        }
+        $content = file_get_contents($this->cache_file);
+        if ($content === false) {
+            error_log("Failed to read cache file {$this->cache_file}");
+            return null;
+        }
+        $data = json_decode($content, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            error_log("Failed to parse cache file {$this->cache_file}: " . json_last_error_msg());
+            return null;
+        }
+        return $data;
+    }
+
+    /**
+     * Save data to cache file with file locking to prevent race conditions.
+     *
+     * @param array $data The data to cache.
+     * @return bool True on success, False on failure.
+     */
+    private function saveCache(array $data): bool {
+        $json = json_encode($data);
+        if ($json === false) {
+            error_log("Failed to encode cache data to JSON");
+            return false;
+        }
+
+        $file = fopen($this->cache_file, 'c');
+        if ($file === false) {
+            error_log("Failed to open cache file {$this->cache_file} for writing");
+            return false;
+        }
+
+        if (flock($file, LOCK_EX)) {
+            ftruncate($file, 0);
+            fwrite($file, $json);
+            fflush($file);
+            flock($file, LOCK_UN);
+            fclose($file);
+            error_log("Cache saved to {$this->cache_file}");
+            return true;
+        } else {
+            error_log("Failed to acquire lock on cache file {$this->cache_file}");
+            fclose($file);
+            return false;
+        }
+    }
+
+    /**
+     * Fetch all release versions (tags) from the GitHub repository, using cache if valid.
+     *
+     * @return array List of version tags in descending order (latest first).
+     * @throws Exception If the request fails.
+     */
+    public function getReleases(): array {
+        if ($this->isCacheValid()) {
+            error_log("Using cached releases from {$this->cache_file} for {$this->owner}/{$this->repo}");
+            $cache = $this->loadCache();
+            if ($cache === null) {
+                error_log("Invalid cache, fetching new data");
+            } else {
+                $releases = array_filter(array_map(function ($release) {
+                    return $release['tag_name'] ?? '';
+                }, $cache));
+                return array_values($releases);
+            }
+        }
+
+        try {
+            error_log("Fetching releases for {$this->owner}/{$this->repo}");
+            $response = $this->makeRequest($this->api_url);
+            $data = json_decode($response, true);
+            if ($data === null) {
+                throw new Exception("Failed to parse API response: " . json_last_error_msg());
+            }
+            $this->saveCache($data);
+            $releases = array_filter(array_map(function ($release) {
+                return $release['tag_name'] ?? '';
+            }, $data));
+            $releases = array_values($releases);
+            error_log("Retrieved and cached " . count($releases) . " releases from {$this->owner}/{$this->repo}");
+            return $releases;
+        } catch (Exception $e) {
+            error_log("Failed to fetch releases: " . $e->getMessage());
+            throw $e;
+        }
+    }
+
+    /**
+     * Get the next version tag that comes after the specified current version.
+     *
+     * @param string $current_version The current version tag (e.g., "1.0.0").
+     * @return string|null The next version tag, or null if it's the latest or not found.
+     */
+    public function getNextVersion(string $current_version): ?string {
+        $releases = $this->getReleases();
+        $index = array_search($current_version, $releases);
+        if ($index === false) {
+            error_log("Version {$current_version} not found in releases");
+            return null;
+        }
+        return $index > 0 ? $releases[$index - 1] : null;
+    }
+
+    /**
+     * Retrieve the MD5 hash of a release asset from its corresponding hash file.
+     *
+     * @param string $version The release tag (e.g., "1.0.0").
+     * @param string $asset_name The asset file name to get the hash for (e.g., "update.tar.gz").
+     * @return string|null The MD5 hash string, or null if not found or invalid.
+     */
+    public function getAssetHash(string $version, string $asset_name): ?string {
+        try {
+            $hashURL = "https://github.com/{$this->owner}/{$this->repo}/releases/download/{$version}/{$this->hash_file}";
+            $hash_response = $this->makeRequest($hashURL);
+
+            $hash_text = trim($hash_response);
+            $lines = explode("\n", $hash_text);
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if (empty($line)) {
+                    continue;
+                }
+                $parts = preg_split('/\s+/', $line, 2);
+                if (count($parts) === 2 && $parts[1] === $asset_name) {
+                    error_log("Retrieved MD5 hash for {$asset_name} in version {$version}");
+                    return $parts[0];
+                }
+            }
+            return null;
+        } catch (Exception $e) {
+            error_log("Failed to fetch asset hash: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Retrieve the changelog for all releases from changelog.json files in JSON format.
+     *
+     * @param string $changelog_file_url Link to file with changelog.
+     * @return array A JSON-compatible array containing the changelog.
+     */
+    public function getChangelog(string $changelog_file_url): array {
+        try {
+            if (!$this->isCacheValid()) {
+                $response = $this->makeRequest($this->api_url);
+                $data = json_decode($response, true);
+                if ($data === null) {
+                    throw new Exception("Failed to parse API response: " . json_last_error_msg());
+                }
+                $this->saveCache($data);
+                error_log("Updated cache for {$this->owner}/{$this->repo}");
+            }
+            $releases = $this->loadCache();
+            if ($releases === null) {
+                error_log("Invalid cache, unable to proceed");
+                return [];
+            }
+
+            $response = $this->makeRequest($changelog_file_url);
+            $changelog = json_decode($response, true);
+            if ($changelog === null) {
+                error_log("Failed to parse changelog JSON");
+                return [];
+            }
+
+            $valid_versions = array_map(function ($release) {
+                return $release['tag_name'] ?? '';
+            }, $releases);
+            $filtered_changelog = array_filter($changelog, function ($entry) use ($valid_versions) {
+                return in_array($entry['version'] ?? '', $valid_versions);
+            });
+            $filtered_changelog = array_values($filtered_changelog);
+            error_log("Successfully retrieved changelog with " . count($filtered_changelog) . " versions after filtering (original: " . count($changelog) . " versions)");
+            return $filtered_changelog;
+        } catch (Exception $e) {
+            error_log("Failed to fetch changelog: " . $e->getMessage());
+            return [];
+        }
+    }
+
+    /**
+     * Validate whether a version string follows the format X.Y.Z.
+     *
+     * @param string $version The version string to validate (e.g., "1.0.0").
+     * @return bool True if valid, False otherwise.
+     * @throws InvalidArgumentException If the version string is too long or contains invalid parts.
+     */
+    public static function isValidVersion(string $version): bool {
+        if (!is_string($version)) {
+            error_log("Version must be a string");
+            return false;
+        }
+
+        if (strlen($version) > 20) {
+            error_log("Version string too long");
+            throw new InvalidArgumentException("Version string is too long");
+        }
+
+        if (!preg_match('/^[0-9]+\.[0-9]+\.[0-9]+$/', $version)) {
+            error_log("Invalid version format: {$version}");
+            return false;
+        }
+
+        $parts = explode('.', $version);
+        if (count($parts) !== 3) {
+            error_log("Version must have three parts: {$version}");
+            return false;
+        }
+
+        foreach ($parts as $part) {
+            $num = (int)$part;
+            if ($num < 0) {
+                error_log("Negative numbers are not allowed in version: {$version}");
+                return false;
+            }
+            if (strlen($part) > 1 && $part[0] === '0') {
+                error_log("Leading zeros are not allowed in version: {$version}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Make an HTTP request using cURL.
+     *
+     * @param string $url The URL to request.
+     * @return string The response body.
+     * @throws Exception If the request fails.
+     */
+    private function makeRequest(string $url): string {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->headers);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'Vateron-Media/XC_VM');
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+
+        $response = curl_exec($ch);
+        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false) {
+            throw new Exception("cURL error: {$error}");
+        }
+
+        if ($http_code !== 200) {
+            switch ($http_code) {
+                case 404:
+                    error_log("Resource not found (404)");
+                    throw new Exception("Resource not found (404)");
+                case 403:
+                    error_log("Access forbidden (403) - Check API rate limits or permissions");
+                    throw new Exception("Access forbidden (403)");
+                case 500:
+                    error_log("Server error (500)");
+                    throw new Exception("Server error (500)");
+                default:
+                    error_log("Unexpected HTTP status code: {$http_code}");
+                    throw new Exception("Unexpected HTTP status code: {$http_code}");
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get update file details for a specific file type and version.
+     *
+     * @param string $file_type The type of update file (main, lb, lb_update).
+     * @param string $version The current version tag (e.g., "1.0.0").
+     * @return array|null Array with URL and MD5 hash, or null if no next version.
+     * @throws Exception If the file type is invalid.
+     */
+    public function getUpdateFile(string $file_type, string $version) {
+        switch ($file_type) {
+            case "main":
+                $update_file = "update.tar.gz";
+                break;
+            case "lb":
+                $update_file = "loadbalancer.tar.gz";
+                break;
+            case "lb_update":
+                $update_file = "loadbalancer_update.tar.gz";
+                break;
+            default:
+                throw new Exception("Not valid file type");
+        }
+        $next_version = $this->getNextVersion($version);
+        if (is_null($next_version)) {
+            return null;
+        }
+        $upd_archive_url = "https://github.com/{$this->owner}/{$this->repo}/releases/download/{$next_version}/{$update_file}";
+        $hash_md5 = $this->getAssetHash($next_version, $update_file);
+
+        $data = ["url" => $upd_archive_url, "md5" => $hash_md5];
+        return $data;
+    }
+
+    /**
+     * Retrieves update information for the specified version
+     * 
+     * @param string $version Current version to check for updates
+     * @return array|null Array with update information or null in case of error
+     * @throws InvalidArgumentException If an incorrect version is passed
+     */
+    public function getUpdate(string $version): ?array {
+        try {
+            // Get the next version
+            $next_version = $this->getNextVersion($version);
+
+            // Form the URL for changelog
+            $changelogUrl = "https://raw.githubusercontent.com/{$this->owner}/{$this->repo}_Update/refs/heads/main/changelog.json";
+            $changelog = $this->getChangelog($changelogUrl);
+
+            // Form the release URL
+            $url = "https://github.com/{$this->owner}/{$this->repo}/releases/tag/{$next_version}";
+
+            return [
+                "version" => $next_version,
+                "changelog" => $changelog,
+                "url" => $url
+            ];
+        } catch (Exception $e) {
+            error_log("Error while fetching update information: " . $e->getMessage());
+            return null;
+        }
+    }
+}
+
+// // Example usage
+// $current = '1.0.2';
+// $repo = new GitHubReleases('Vateron-Media', 'XC_VM');
+//     $next_version = $repo->getNextVersion($current);
+//     echo "🔁 Next version after {$current}: {$next_version}\n";
+
+//     $notes = $repo->getUpdate($current);
+//     print_r($notes);
+
+//     print_r($repo->getUpdateFile("main", $current));

--- a/src/includes/xc_vm.php
+++ b/src/includes/xc_vm.php
@@ -4188,27 +4188,6 @@ class CoreUtilities {
 		self::$db->query("REVOKE ALL PRIVILEGES ON `" . self::$rConfig['database'] . "`.* FROM '" . self::$rConfig['username'] . "'@'" . $Host . "';");
 	}
 
-	/**
-	 * Retrieves the API IP address from a JSON source.
-	 *
-	 * @return string|false The API IP address if found, otherwise false.
-	 */
-	public static function getApiIP() {
-		$url = 'https://raw.githubusercontent.com/Vateron-Media/XC_VM_Update/refs/heads/main/api_server.json';
-
-		// Get the JSON content from the URL
-		$json = file_get_contents($url);
-		if ($json === false) {
-			return false;
-		}
-
-		// Decode the JSON into an associative array
-		$data = json_decode($json, true);
-		if (json_last_error() !== JSON_ERROR_NONE || empty($data['ip'])) {
-			return false;
-		}
-		return $data['ip'];
-	}
 	public static function getMemory() {
 		try {
 			$rFree = explode("\n", file_get_contents('/proc/meminfo'));

--- a/src/www/constants.php
+++ b/src/www/constants.php
@@ -22,6 +22,8 @@ if (!defined('TMP_PATH')) {
 }
 
 define('XC_VM_VERSION', '1.0.4');
+define('GIT_OWNER', 'Vateron-Media');
+define('GIT_REPO', 'XC_VM');
 define('CONFIG_PATH', MAIN_HOME . 'config/');
 define('BIN_PATH', MAIN_HOME . 'bin/');
 define('INCLUDES_PATH', MAIN_HOME . 'includes/');

--- a/src/www/init.php
+++ b/src/www/init.php
@@ -3,6 +3,7 @@
 require_once 'constants.php';
 require_once INCLUDES_PATH . 'xc_vm.php';
 require_once INCLUDES_PATH . 'pdo.php';
+require_once INCLUDES_PATH . 'libs/GithubReleases.php';
 
 if (!function_exists('getallheaders')) {
 	function getallheaders() {
@@ -23,6 +24,7 @@ if (basename(__FILE__) == basename($_SERVER['SCRIPT_FILENAME'])) {
 }
 
 $rFilename = strtolower(basename(get_included_files()[0], '.php'));
+$gitRelease = new GitHubReleases(GIT_OWNER, GIT_REPO);
 
 if (!in_array($rFilename, array('enigma2', 'epg', 'playlist', 'api', 'xplugin', 'live', 'proxy_api', 'thumb', 'timeshift', 'vod')) || isset($argc)) {
 	$db = new Database($_INFO['username'], $_INFO['password'], $_INFO['database'], $_INFO['hostname'], $_INFO['port']);;


### PR DESCRIPTION
The update retrieval class has been fully migrated into the panel itself, removing the need for an external API intermediary. This change makes the panel independent from third-party servers and improves overall security.

## Краткое содержание от Sourcery

Перенести механизм обновления на GitHub Releases путем интеграции нового сервиса GitHubReleases и устранения зависимости от внешнего API-сервера

Улучшения:
- Добавить библиотеку GitHubReleases для получения данных о релизах и активах с GitHub с кэшированием и проверкой MD5
- Заменить прямые вызовы внешнего API в скриптах CLI и cron вызовами методов GitHubReleases
- Ввести константы GIT_OWNER и GIT_REPO и создать экземпляр GitHubReleases в init.php для централизации логики обновления

Задачи:
- Удалить устаревший вспомогательный метод getApiIP и связанную с ним логику получения внешних JSON-данных

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate update mechanism to GitHub Releases by integrating a new GitHubReleases service and eliminating dependency on an external API server

Enhancements:
- Add GitHubReleases library for fetching release and asset data from GitHub with caching and MD5 validation
- Replace direct external API calls in CLI and cron scripts with calls to GitHubReleases methods
- Introduce GIT_OWNER and GIT_REPO constants and instantiate GitHubReleases in init.php to centralize update logic

Chores:
- Remove legacy getApiIP helper and associated external JSON fetching logic

</details>