### PR TITLE
Fixed call to headerStats()

### DIFF
--- a/src/admin/archive.php
+++ b/src/admin/archive.php
@@ -165,7 +165,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/asns.php
+++ b/src/admin/asns.php
@@ -100,7 +100,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/backups.php
+++ b/src/admin/backups.php
@@ -143,7 +143,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/bouquet.php
+++ b/src/admin/bouquet.php
@@ -326,7 +326,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/bouquet_order.php
+++ b/src/admin/bouquet_order.php
@@ -104,7 +104,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/bouquet_sort.php
+++ b/src/admin/bouquet_sort.php
@@ -85,7 +85,7 @@ orderListings($rChannels, $rMovies, $rRadios, $rSeries, $rListings, $rOrdered);
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/bouquets.php
+++ b/src/admin/bouquets.php
@@ -94,7 +94,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/cache.php
+++ b/src/admin/cache.php
@@ -285,7 +285,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/channel_order.php
+++ b/src/admin/channel_order.php
@@ -297,7 +297,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/client_logs.php
+++ b/src/admin/client_logs.php
@@ -96,7 +96,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/code.php
+++ b/src/admin/code.php
@@ -239,7 +239,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/codes.php
+++ b/src/admin/codes.php
@@ -95,7 +95,7 @@
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/created_channel.php
+++ b/src/admin/created_channel.php
@@ -589,7 +589,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/created_channel_mass.php
+++ b/src/admin/created_channel_mass.php
@@ -312,7 +312,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/created_channels.php
+++ b/src/admin/created_channels.php
@@ -146,7 +146,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/credit_logs.php
+++ b/src/admin/credit_logs.php
@@ -83,7 +83,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/dashboard.php
+++ b/src/admin/dashboard.php
@@ -752,7 +752,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/edit_profile.php
+++ b/src/admin/edit_profile.php
@@ -141,7 +141,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/enigma.php
+++ b/src/admin/enigma.php
@@ -309,7 +309,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/enigma_mass.php
+++ b/src/admin/enigma_mass.php
@@ -315,7 +315,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/enigmas.php
+++ b/src/admin/enigmas.php
@@ -118,7 +118,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/epg.php
+++ b/src/admin/epg.php
@@ -136,7 +136,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/epg_view.php
+++ b/src/admin/epg_view.php
@@ -188,7 +188,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/epgs.php
+++ b/src/admin/epgs.php
@@ -95,7 +95,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/episode.php
+++ b/src/admin/episode.php
@@ -563,7 +563,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/episodes.php
+++ b/src/admin/episodes.php
@@ -310,7 +310,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/episodes_mass.php
+++ b/src/admin/episodes_mass.php
@@ -339,7 +339,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/fingerprint.php
+++ b/src/admin/fingerprint.php
@@ -184,7 +184,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/group.php
+++ b/src/admin/group.php
@@ -493,7 +493,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/groups.php
+++ b/src/admin/groups.php
@@ -115,7 +115,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/hmac.php
+++ b/src/admin/hmac.php
@@ -107,7 +107,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/hmacs.php
+++ b/src/admin/hmacs.php
@@ -95,7 +95,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/ip.php
+++ b/src/admin/ip.php
@@ -87,7 +87,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/ips.php
+++ b/src/admin/ips.php
@@ -95,7 +95,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/isp.php
+++ b/src/admin/isp.php
@@ -95,7 +95,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/isps.php
+++ b/src/admin/isps.php
@@ -85,7 +85,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/line.php
+++ b/src/admin/line.php
@@ -400,7 +400,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/line_activity.php
+++ b/src/admin/line_activity.php
@@ -140,7 +140,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/line_ips.php
+++ b/src/admin/line_ips.php
@@ -108,7 +108,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/line_mass.php
+++ b/src/admin/line_mass.php
@@ -354,7 +354,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/lines.php
+++ b/src/admin/lines.php
@@ -135,7 +135,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/live_connections.php
+++ b/src/admin/live_connections.php
@@ -174,7 +174,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/login_logs.php
+++ b/src/admin/login_logs.php
@@ -66,7 +66,7 @@
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/mag.php
+++ b/src/admin/mag.php
@@ -385,7 +385,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/mag_events.php
+++ b/src/admin/mag_events.php
@@ -64,7 +64,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/mag_mass.php
+++ b/src/admin/mag_mass.php
@@ -395,7 +395,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/mags.php
+++ b/src/admin/mags.php
@@ -114,7 +114,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/mass_delete.php
+++ b/src/admin/mass_delete.php
@@ -717,7 +717,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/movie.php
+++ b/src/admin/movie.php
@@ -662,7 +662,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/movie_mass.php
+++ b/src/admin/movie_mass.php
@@ -333,7 +333,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/movies.php
+++ b/src/admin/movies.php
@@ -184,7 +184,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/mysql_syslog.php
+++ b/src/admin/mysql_syslog.php
@@ -62,7 +62,7 @@
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/ondemand.php
+++ b/src/admin/ondemand.php
@@ -104,7 +104,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/package.php
+++ b/src/admin/package.php
@@ -356,7 +356,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/packages.php
+++ b/src/admin/packages.php
@@ -105,7 +105,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/panel_logs.php
+++ b/src/admin/panel_logs.php
@@ -64,7 +64,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/plex.php
+++ b/src/admin/plex.php
@@ -112,7 +112,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/plex_add.php
+++ b/src/admin/plex_add.php
@@ -327,7 +327,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/process_monitor.php
+++ b/src/admin/process_monitor.php
@@ -318,7 +318,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/profile.php
+++ b/src/admin/profile.php
@@ -333,7 +333,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/profiles.php
+++ b/src/admin/profiles.php
@@ -119,7 +119,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/provider.php
+++ b/src/admin/provider.php
@@ -214,7 +214,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/providers.php
+++ b/src/admin/providers.php
@@ -122,7 +122,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/proxies.php
+++ b/src/admin/proxies.php
@@ -143,7 +143,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/proxy.php
+++ b/src/admin/proxy.php
@@ -246,7 +246,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/queue.php
+++ b/src/admin/queue.php
@@ -64,7 +64,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/quick_tools.php
+++ b/src/admin/quick_tools.php
@@ -550,7 +550,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/radio.php
+++ b/src/admin/radio.php
@@ -399,7 +399,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/radio_mass.php
+++ b/src/admin/radio_mass.php
@@ -395,7 +395,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/radios.php
+++ b/src/admin/radios.php
@@ -141,7 +141,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/record.php
+++ b/src/admin/record.php
@@ -275,7 +275,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/restream_logs.php
+++ b/src/admin/restream_logs.php
@@ -75,7 +75,7 @@
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/review.php
+++ b/src/admin/review.php
@@ -725,7 +725,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/rtmp_ip.php
+++ b/src/admin/rtmp_ip.php
@@ -139,7 +139,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/rtmp_ips.php
+++ b/src/admin/rtmp_ips.php
@@ -108,7 +108,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/rtmp_monitor.php
+++ b/src/admin/rtmp_monitor.php
@@ -212,7 +212,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/serie.php
+++ b/src/admin/serie.php
@@ -485,7 +485,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/series.php
+++ b/src/admin/series.php
@@ -124,7 +124,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/series_mass.php
+++ b/src/admin/series_mass.php
@@ -225,7 +225,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/server.php
+++ b/src/admin/server.php
@@ -665,7 +665,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/server_install.php
+++ b/src/admin/server_install.php
@@ -224,7 +224,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/server_order.php
+++ b/src/admin/server_order.php
@@ -111,7 +111,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/server_view.php
+++ b/src/admin/server_view.php
@@ -395,7 +395,7 @@ include 'header.php'; ?>
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/servers.php
+++ b/src/admin/servers.php
@@ -294,7 +294,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/settings.php
+++ b/src/admin/settings.php
@@ -2262,7 +2262,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/settings_plex.php
+++ b/src/admin/settings_plex.php
@@ -278,7 +278,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/settings_watch.php
+++ b/src/admin/settings_watch.php
@@ -312,7 +312,7 @@ include 'header.php';
                 window.rSwitches[$(html).attr("id")] = switchery;
             });
             setTimeout(pingSession, 30000);
-            <?php if (!$rMobile || $rSettings['header_stats']): ?>
+            <?php if (!$rMobile && $rSettings['header_stats']): ?>
                 headerStats();
             <?php endif; ?>
             bindHref();

--- a/src/admin/stream.php
+++ b/src/admin/stream.php
@@ -901,7 +901,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/stream_categories.php
+++ b/src/admin/stream_categories.php
@@ -159,7 +159,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/stream_category.php
+++ b/src/admin/stream_category.php
@@ -173,7 +173,7 @@ include 'header.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/stream_errors.php
+++ b/src/admin/stream_errors.php
@@ -100,7 +100,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/stream_mass.php
+++ b/src/admin/stream_mass.php
@@ -205,7 +205,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/stream_rank.php
+++ b/src/admin/stream_rank.php
@@ -125,7 +125,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/stream_review.php
+++ b/src/admin/stream_review.php
@@ -282,7 +282,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/stream_tools.php
+++ b/src/admin/stream_tools.php
@@ -224,7 +224,7 @@ include 'header.php';
             window.rSwitches[$(html).attr("id")] = switchery;
         });
         setTimeout(pingSession, 30000);
-        <?php if (!$rMobile || $rSettings['header_stats']): ?>
+        <?php if (!$rMobile && $rSettings['header_stats']): ?>
             headerStats();
         <?php endif; ?>
         bindHref();

--- a/src/admin/stream_view.php
+++ b/src/admin/stream_view.php
@@ -615,7 +615,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/streams.php
+++ b/src/admin/streams.php
@@ -348,7 +348,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/theft_detection.php
+++ b/src/admin/theft_detection.php
@@ -112,7 +112,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/ticket.php
+++ b/src/admin/ticket.php
@@ -47,7 +47,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/tickets.php
+++ b/src/admin/tickets.php
@@ -90,7 +90,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/user.php
+++ b/src/admin/user.php
@@ -180,7 +180,7 @@ include 'header.php';
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/user_logs.php
+++ b/src/admin/user_logs.php
@@ -63,7 +63,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/user_mass.php
+++ b/src/admin/user_mass.php
@@ -106,7 +106,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/useragent.php
+++ b/src/admin/useragent.php
@@ -93,7 +93,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/useragents.php
+++ b/src/admin/useragents.php
@@ -70,7 +70,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/users.php
+++ b/src/admin/users.php
@@ -136,7 +136,7 @@ include 'header.php';
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();

--- a/src/admin/watch.php
+++ b/src/admin/watch.php
@@ -82,7 +82,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/watch_add.php
+++ b/src/admin/watch_add.php
@@ -530,7 +530,7 @@ include 'footer.php'; ?>
 			window.rSwitches[$(html).attr("id")] = switchery;
 		});
 		setTimeout(pingSession, 30000);
-		<?php if (!$rMobile || $rSettings['header_stats']): ?>
+		<?php if (!$rMobile && $rSettings['header_stats']): ?>
 			headerStats();
 		<?php endif; ?>
 		bindHref();

--- a/src/admin/watch_output.php
+++ b/src/admin/watch_output.php
@@ -81,7 +81,7 @@ include 'footer.php'; ?>
 					window.rSwitches[$(html).attr("id")] = switchery;
 				});
 				setTimeout(pingSession, 30000);
-				<?php if (!$rMobile || $rSettings['header_stats']): ?>
+				<?php if (!$rMobile && $rSettings['header_stats']): ?>
 					headerStats();
 				<?php endif; ?>
 				bindHref();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change headerStats() conditional from OR to AND to prevent it running on mobile or when header_stats is disabled across all admin pages.