### PR TITLE
fix: player_api.php Xtream Codes apps compatibility

### DIFF
--- a/src/www/player_api.php
+++ b/src/www/player_api.php
@@ -691,10 +691,11 @@ if ($rUserInfo) {
 				'message' => StreamingUtilities::$rSettings['message_of_day'],
 				'auth' => 1,
 				'status' => 'Active',
-				'exp_date' => $rUserInfo['exp_date'],
-				'is_trial' => $rUserInfo['is_trial'],
-				'created_at' => $rUserInfo['created_at'],
-				'max_connections' => $rUserInfo['max_connections'],
+				'exp_date' => $rUserInfo['exp_date'] !== null ? strval($rUserInfo['exp_date']) : null,
+				'is_trial' => strval($rUserInfo['is_trial'] ?? '0'),
+				'active_cons' => strval($rUserInfo['active_cons'] ?? '0'),
+				'created_at' => strval($rUserInfo['created_at'] ?? ''),
+				'max_connections' => strval($rUserInfo['max_connections'] ?? '1'),
 				'allowed_output_formats' => getOutputFormats($rUserInfo['allowed_outputs'])
 			];
 
@@ -703,16 +704,15 @@ if ($rUserInfo) {
 			}
 
 			$output['server_info'] = [
-				'xui' => true,
-				'version' => XC_VM_VERSION,
 				'url' => $rDomain,
-				'port' => StreamingUtilities::$rServers[SERVER_ID]['http_broadcast_port'],
-				'https_port' => StreamingUtilities::$rServers[SERVER_ID]['https_broadcast_port'],
+				'port' => strval(StreamingUtilities::$rServers[SERVER_ID]['http_broadcast_port']),
+				'https_port' => strval(StreamingUtilities::$rServers[SERVER_ID]['https_broadcast_port']),
 				'server_protocol' => StreamingUtilities::$rServers[SERVER_ID]['server_protocol'],
-				'rtmp_port' => StreamingUtilities::$rServers[SERVER_ID]['rtmp_port'],
+				'rtmp_port' => strval(StreamingUtilities::$rServers[SERVER_ID]['rtmp_port']),
 				'timestamp_now' => time(),
 				'time_now' => date('Y-m-d H:i:s'),
-				'timezone' => StreamingUtilities::$rSettings['force_epg_timezone'] ? 'UTC' : StreamingUtilities::$rSettings['default_timezone']
+				'timezone' => '',
+				'process' => true
 			];
 			break;
 	}


### PR DESCRIPTION
## Summary

This PR fixes compatibility issues with Xtream Codes compatible apps (IPTV players) that were failing to work with XC_VM.

### Problems Fixed:
- **"Checking server" infinite loop** - Apps got stuck because `active_cons` field was missing from user_info
- **App crash on login** - Apps crashed after authentication due to incorrect JSON data types and unexpected fields

### Changes Made:
- Add missing `active_cons` field to `user_info`
- Convert numeric fields to strings to match Xtream Codes API format:
  - `is_trial`, `active_cons`, `created_at`, `max_connections`
  - `port`, `https_port`, `rtmp_port`
- Add `process: true` to `server_info` (required by some apps)
- Remove `xui` and `version` fields from `server_info` (not part of XC API spec)
- Set `timezone` to empty string (matches XC API behavior)

### Testing
Compared API response format against a working Xtream Codes server and verified compatibility with IPTV player apps.

### Before (broken):
```json
{
  "user_info": {
    "is_trial": 0,
    "exp_date": null
  },
  "server_info": {
    "xui": true,
    "version": "1.2.7",
    "port": 80,
    "timezone": "Europe/London"
  }
}
```

### After (working):
```json
{
  "user_info": {
    "is_trial": "0",
    "active_cons": "0",
    "exp_date": null
  },
  "server_info": {
    "port": "80",
    "timezone": "",
    "process": true
  }
}
```

## Test plan
- [ ] Test with various Xtream Codes compatible IPTV apps
- [ ] Verify authentication works without "Checking server" message
- [ ] Verify app doesn't crash after login
- [ ] Verify channel listing and playback work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Xtream Codes player API compatibility and add configurable handling for streams with corrupted PMT/codec metadata.

New Features:
- Add skip_ffprobe stream option to bypass ffprobe codec detection and assume h264 video with AAC audio for problematic streams.
- Add force_input_acodec stream option to force FFmpeg to interpret the input audio stream as a specific codec for corrupted PMT sources.
- Expose skip_ffprobe and force_input_acodec controls in the stream admin UI and wire them into stream creation APIs.
- Introduce a database migration to safely add the new skip_ffprobe and force_input_acodec stream arguments on existing installations.

Enhancements:
- Align player_api user_info and server_info response formats with Xtream Codes expectations, including string-typed numeric fields, active_cons reporting, and adjusted server metadata.
- Tighten live streaming proxy handling logic to treat missing or false proxy values consistently.