### PR TITLE
Missing SQL query for Live and Movies - Stream Providers

### DIFF
--- a/src/admin/provider.php
+++ b/src/admin/provider.php
@@ -130,6 +130,7 @@ include 'header.php'; ?>
                                                         </tr>
                                                     </thead>
                                                     <tbody>
+                                                        <?php $db->query('SELECT `stream_id`, `category_array`, `stream_display_name`, `modified`, `stream_icon` FROM `providers_streams` WHERE `provider_id` = ? AND `type` = \'live\' ORDER BY `modified` DESC, `stream_id` ASC;', CoreUtilities::$rRequest['id']); ?>
                                                         <?php foreach ($db->get_rows() as $rRow) : ?>
                                                             <?php
                                                             $rStreamURL = (($rProvider['ssl'] ? 'https' : 'http')) . '://' . $rProvider['ip'] . ':' . $rProvider['port'] . '/live/' . $rProvider['username'] . '/' . $rProvider['password'] . '/' . $rRow['stream_id'] . (($rProvider['hls'] ? '.m3u8' : ($rProvider['legacy'] ? '.ts' : '')));
@@ -166,6 +167,7 @@ include 'header.php'; ?>
                                                         </tr>
                                                     </thead>
                                                     <tbody>
+                                                        <?php $db->query('SELECT `stream_id`, `category_array`, `stream_display_name`, `modified`, `stream_icon`, `channel_id` FROM `providers_streams` WHERE `provider_id` = ? AND `type` = \'movie\' ORDER BY `modified` DESC, `stream_id` ASC;', CoreUtilities::$rRequest['id']); ?>
                                                         <?php foreach ($db->get_rows() as $rRow) : ?>
                                                             <?php
                                                             $rStreamURL = (($rRow['ssl'] ? 'https' : 'http')) . '://' . $rProvider['ip'] . ':' . $rProvider['port'] . '/movie/' . $rProvider['username'] . '/' . $rProvider['password'] . '/' . $rRow['stream_id'] . '.' . $rRow['channel_id'];


### PR DESCRIPTION
## PROBLEM
The providers view for Live and Movies did not execute the required SQL queries to load stream data. As a result, Live and Movie streams associated with a provider were not being fetched, leading to missing or empty listings in the interface.

## SOLUTION
Add the missing SQL queries to explicitly retrieve Live and Movie streams from `providers_streams`, filtered by `provider_id` and `type`, and ordered consistently by modification date and stream ID.

## CHANGES

### Backend
- Added SQL query to load Movie streams (`type = 'movie'`) for a given provider
- Added SQL query to load Live streams (`type = 'live'`) for a given provider
- Queries retrieve relevant stream metadata:
  - `stream_id`
  - `category_array`
  - `stream_display_name`
  - `modified`
  - `stream_icon`
  - `channel_id` (movies only)
- Ensured stable ordering using `modified` (DESC) and `stream_id` (ASC)

### Database
- No schema changes required
- Reuses existing `providers_streams` table and indexes

## USAGE
- No configuration or migration required
- Live and Movie streams are now correctly loaded wherever provider-based listings are rendered

## SUMMARY
Fix missing SQL queries for provider Live and Movie streams to restore correct data loading and consistent behavior.

## Summary by Sourcery

Ensure provider pages correctly load associated Live and Movie streams from the database.

Bug Fixes:
- Load Live streams for a provider by querying providers_streams with type='live'.
- Load Movie streams for a provider by querying providers_streams with type='movie'.