### PR TITLE
fix: Improve bouquet handling in force reload EPG

### DIFF
--- a/src/crons/epg.php
+++ b/src/crons/epg.php
@@ -261,7 +261,7 @@ function getBouquetGroups() {
 		$rBouquets = json_decode($rRow['bouquet'] ?? null, true);
 
 		if (!is_array($rBouquets) || empty($rBouquets)) {
-			print_log("[XMLTV] Skipping invalid/empty bouquet value: " . var_export($rBouquetsRaw, true));
+			print_log("[XMLTV] Skipping invalid/empty bouquet value: " . var_export($rBouquets, true));
 			continue;
 		}
 


### PR DESCRIPTION
### Summary
This PR hardens the EPG cron’s bouquet handling so that rows in the lines table without a valid bouquet no longer break XMLTV generation.

### Problem
Previously, getBouquetGroups() assumed that lines.bouquet was always valid JSON containing a non‑empty array of bouquet IDs. In production, however, some users/lines can exist without any bouquet configured (e.g. NULL, empty string).

**When such a row was encountered:**
- json_decode($rRow['bouquet'], true) returned null.
- Subsequent operations on this value (like sorting) triggered a runtime error.
- As a result, the EPG cron stopped before logging the usual "[XMLTV] Found $count bouquet groups (including 'all')", and XMLTV generation didn’t complete.

### Change
In src/crons/epg.php, inside getBouquetGroups(), we now safely decode and validate the bouquet field:

```
$rBouquets = json_decode($rRow['bouquet'] ?? null, true);

if (!is_array($rBouquets) || empty($rBouquets)) {
    print_log("[XMLTV] Skipping invalid/empty bouquet value: " . var_export($rBouquetsRaw, true));
    continue;
}
```

### Key points:

We guard against NULL/empty/invalid JSON by checking is_array($rBouquets) and !empty($rBouquets).
If the value is invalid, we:
Log a clear diagnostic message.
Skip the row instead of letting the script crash.

### Impact
**Stability:** Users/lines without a bouquet no longer cause the EPG cron to fail.
**Observability:** Invalid or empty bouquet values are now visible in the logs.
**Behavior:** Valid bouquets continue to be processed as before; only broken entries are skipped.

## Summary by Sourcery

Bug Fixes:
- Skip lines with invalid, null, or empty bouquet JSON when building bouquet groups in the EPG cron, logging them instead of causing a runtime error.