### PR TITLE
performance(nginx): Utilize `reuseport` instead of `mutli_accept` and `accept_mutex`

### DIFF
--- a/lb_configs/nginx.conf
+++ b/lb_configs/nginx.conf
@@ -5,8 +5,6 @@ worker_rlimit_nofile 300000;
 events {
     worker_connections  16000;
     use epoll;
-    accept_mutex on;
-	multi_accept on;
 }
 
 thread_pool pool_xc_vm threads=32 max_queue=0;

--- a/src/bin/nginx/conf/nginx.conf
+++ b/src/bin/nginx/conf/nginx.conf
@@ -5,8 +5,6 @@ worker_rlimit_nofile 300000;
 events {
     worker_connections  16000;
     use epoll;
-    accept_mutex on;
-    multi_accept on;
 }
 
 thread_pool pool_xc_vm threads=32 max_queue=0;

--- a/src/bin/nginx/conf/ports/http.conf
+++ b/src/bin/nginx/conf/ports/http.conf
@@ -1,1 +1,1 @@
-listen 80;
+listen 80 reuseport;

--- a/src/bin/nginx/conf/ports/https.conf
+++ b/src/bin/nginx/conf/ports/https.conf
@@ -1,1 +1,1 @@
-listen 443 ssl;
+listen 443 ssl reuseport;


### PR DESCRIPTION
Deep Dive into 

https://www.f5.com/company/blog/nginx/socket-sharding-nginx-release-1-9-1

**1. `accept_mutex` (The "Turn-Taking" Approach)**

When enabled (`accept_mutex on;`), NGINX forces worker processes to take turns accepting new connections, considered legacy. Not needed if using modern kernels with `EPOLLEXCLUSIVE` or `reuseport`.

**2. `reuseport` (The "Kernel-Level Sharding" Approach).**

Enables the `SO_REUSEPORT` socket option (introduced in Linux 3.9). Each NGINX worker creates its own listening socket, allowing them all to accept connections directly from the kernel. Requires kernel support (Linux 3.9+).Performance Impact: Studies showed `reuseport` reducing latency by nearly 10-fold and increasing requests per second by 2-3 times compared to `accept_mutex`.