### PR TITLE
fix(nginx): reimplement `mutli_accept on;`

### DIFF
--- a/lb_configs/nginx.conf
+++ b/lb_configs/nginx.conf
@@ -5,6 +5,7 @@ worker_rlimit_nofile 300000;
 events {
     worker_connections  16000;
     use epoll;
+	multi_accept on;
 }
 
 thread_pool pool_xc_vm threads=32 max_queue=0;

--- a/src/bin/nginx/conf/nginx.conf
+++ b/src/bin/nginx/conf/nginx.conf
@@ -5,6 +5,7 @@ worker_rlimit_nofile 300000;
 events {
     worker_connections  16000;
     use epoll;
+    multi_accept on;
 }
 
 thread_pool pool_xc_vm threads=32 max_queue=0;


### PR DESCRIPTION
Fixes error in last commit removing `mutli_accept on;`. It should be used in conjunction with `reuseport`, a replacement for `accept_mutex`.

## Summary by Sourcery

Restore nginx multi_accept setting in load balancer configurations to work correctly with reuseport.