### PR TITLE
feat(geoip): fetch GeoLite2 (City/Country/ASN) on install and update

### DIFF
--- a/install
+++ b/install
@@ -2435,6 +2435,16 @@ if __name__ == "__main__":
             f"/home/xc_vm/bin/php/bin/php {startup_cmd} startup >/dev/null 2>&1"
         )
 
+    # Download GeoLite2 GeoIP databases (City/Country/ASN). They are no longer
+    # bundled in the repo/release archive, so fetch them from the XC_VM_Update
+    # release on install. This also refreshes bin/maxmind/version.json.
+    # Non-fatal: run_command never raises, so a download failure won't abort.
+    if os.path.exists(startup_cmd):
+        printc("Downloading GeoLite2 GeoIP databases...", col.OKBLUE)
+        run_command(
+            f"/home/xc_vm/bin/php/bin/php {startup_cmd} cron:maxmind --force"
+        )
+
     time.sleep(3)
 
     # Final restart

--- a/src/cli/Commands/UpdateCommand.php
+++ b/src/cli/Commands/UpdateCommand.php
@@ -156,6 +156,16 @@ class UpdateCommand implements CommandInterface {
 				exec('sudo systemctl daemon-reload');
 				exec("sudo echo 'net.ipv4.ip_unprivileged_port_start=0' > /etc/sysctl.d/50-allports-nonroot.conf && sudo sysctl --system");
 				exec('sudo ' . PHP_BIN . ' ' . MAIN_HOME . 'console.php status');
+
+				// Ensure GeoLite2 databases are present/refreshed after an update.
+				// They are no longer shipped in the update archive, so fetch them
+				// from the XC_VM_Update release. Best-effort: run in background so a
+				// slow/failed download never blocks or fails the update.
+				if (ServerRepository::getAll()[SERVER_ID]['is_main']) {
+					UpdateLogger::info('Refreshing GeoLite2 databases (background)');
+					exec('sudo ' . PHP_BIN . ' ' . MAIN_HOME . 'console.php cron:maxmind --force >/dev/null 2>&1 &');
+				}
+
 				UpdateLogger::info('Post-update completed successfully');
 				break;
 		}

--- a/src/core/Updates/GithubReleases.php
+++ b/src/core/Updates/GithubReleases.php
@@ -423,7 +423,7 @@ class GitHubReleases {
         $data_files = array();
 
         // Iterate over required GeoLite2 database files
-        foreach (["GeoLite2-City.mmdb", "GeoLite2-Country.mmdb"] as $file) {
+        foreach (["GeoLite2-City.mmdb", "GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb"] as $file) {
             // Construct the GitHub release download URL
             $file_url = "https://github.com/{$this->owner}/{$this->repo}/releases/download/{$latest_version}/{$file}";
 


### PR DESCRIPTION
GeoLite2-City/Country are no longer bundled in the repo/release archive, so fetch them (plus ASN) from the XC_VM_Update release:
- getGeolite(): include GeoLite2-ASN.mmdb
- install: run cron:maxmind --force after setup
- UpdateCommand post-update: background GeoLite refresh on MAIN Reuses the existing MaxMindCronJob mechanism; version.json is updated by it.

<!--
  Thanks for contributing to XC_VM!
  Please fill in the sections below and complete the checklist.
-->

## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [x] Code follows the project conventions (see `.github/instructions/php-conventions.instructions.md`).
- [x] `bash tools/php_syntax_check.sh` passes locally.
- [x] Unit tests pass: `php tools/.bin/phpunit.phar -c tests/phpunit.xml.dist`.
- [ ] Added/updated tests for the change where applicable.
- [ ] Documentation updated where applicable (`docs/`, README).
- [ ] No large binaries added outside Git LFS (`src/bin/**` binaries belong in LFS).
- [x] No secrets, credentials, or `.env` files committed.

## Summary by Sourcery

Fetch GeoLite2 databases dynamically and ensure they are refreshed during install and update flows.

New Features:
- Download the GeoLite2 ASN database alongside existing City and Country databases from the GitHub release.

Enhancements:
- Trigger a background GeoLite2 refresh via the existing MaxMind cron job after updates on the main server to keep IP geolocation data current.
- Run the MaxMind cron job during installation to ensure GeoLite2 databases are present without bundling them in the release archive.