### PR TITLE
UCS integration, added rUserID as the 6th parameter of the getStreami…

### DIFF
--- a/src/public/stream/auth.php
+++ b/src/public/stream/auth.php
@@ -238,6 +238,7 @@ if ($rExtension) {
 	if ($rUserInfo || $rIsHMAC) {
 		$rDeny = false;
 		BruteforceGuard::checkAuthFlood($rUserInfo, $rIP);
+		$rUserID = $rUserInfo['id'] ?? null;
 
 		if (($rServers[SERVER_ID]['enable_proxy'] && !($rProxies[$_SERVER['HTTP_X_IP']] ?? null) && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
 			generateError('PROXY_ACCESS_DENIED');
@@ -448,7 +449,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 				$rStreamInfo = json_decode($rChannelInfo['stream_info'] ?? '', true);
 				$rVideoCodec = ($rStreamInfo['codecs']['video']['codec_name'] ?? 'h264');
 
@@ -482,7 +483,7 @@ if ($rExtension) {
 										$rAdaptiveInfo['redirect_id'] = $rProxyID;
 									}
 
-									$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rAdaptiveInfo['redirect_id'], ($rAdaptiveInfo['originator_id'] ?? null), $rForceHTTP);
+									$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rAdaptiveInfo['redirect_id'], ($rAdaptiveInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 								} else {
 									$rAdaptiveInfo = $rChannelInfo;
 								}
@@ -578,7 +579,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 
 				if ($rChannelInfo['direct_proxy']) {
 					$rChannelInfo['bitrate'] = (json_decode($rChannelInfo['movie_properties'] ?? '', true)['duration_secs'] ?? 0);
@@ -629,7 +630,7 @@ if ($rExtension) {
 				$rRedirectID = $rProxyID;
 			}
 
-			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rRedirectID, ($rOriginatorID ?: null), $rForceHTTP);
+			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rRedirectID, ($rOriginatorID ?: null), $rForceHTTP, $rUserID);
 			$rStartDate = $rRequest['start'];
 			$rDuration = intval($rRequest['duration']);
 
@@ -708,7 +709,7 @@ if ($rExtension) {
 				$rStreamInfo['info']['vframes_server_id'] = $rProxyID;
 			}
 
-			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rStreamInfo['info']['vframes_server_id'], $rOriginatorID, $rForceHTTP);
+			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rStreamInfo['info']['vframes_server_id'], $rOriginatorID, $rForceHTTP, $rUserID);
 			$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 			header('Location: ' . $rURL . '/thauth/' . $rToken);
 
@@ -730,7 +731,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?: null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?: null), $rForceHTTP, $rUserID);
 				$rTokenData = array('stream_id' => $rStreamID, 'sub_id' => (intval($rRequest['sid']) ?: 0), 'webvtt' => (intval($rRequest['webvtt']) ?: 0), 'expires' => time() + 5);
 				$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 				header('Location: ' . $rURL . '/subauth/' . $rToken);

--- a/src/streaming/Delivery/StreamRedirector.php
+++ b/src/streaming/Delivery/StreamRedirector.php
@@ -162,7 +162,8 @@ class StreamRedirector {
 		return (!empty($rOutput) ? $rOutput : false);
 	}
 
-	public static function getStreamingURL($rSettings, $rServers, $rServerID = null, $rOriginatorID = null, $rForceHTTP = false) {
+	public static function getStreamingURL($rSettings, $rServers, $rServerID = null, $rOriginatorID = null, $rForceHTTP = false, $rUserID = null) { 
+		//$rUserID is used to redirect clients with different subdomain to the LB server
 		if (!isset($rServerID)) {
 			$rServerID = SERVER_ID;
 		}
@@ -181,6 +182,10 @@ class StreamRedirector {
 		} else {
 			if ($rServers[$rServerID]['random_ip'] && 0 < count($rServers[$rServerID]['domains']['urls'])) {
 				$rDomain = $rServers[$rServerID]['domains']['urls'][array_rand($rServers[$rServerID]['domains']['urls'])];
+				//line_id : 10 => wildcard.lb1.com => 10.lb1.com
+				if($rUserID && strpos($rDomain, 'wildcard.') !== false) { 
+					$rDomain = str_replace('wildcard.', $rUserID . '.', $rDomain);
+				}
 			}
 		}
 		if ($rDomain) {


### PR DESCRIPTION
…ngURL function

<!--
  Thanks for contributing to XC_VM!
  Please fill in the sections below and complete the checklist.
-->

## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [x] Code follows the project conventions (see `.github/instructions/php-conventions.instructions.md`).
- [x] `bash tools/php_syntax_check.sh` passes locally.
- [x] Unit tests pass: `php tools/.bin/phpunit.phar -c tests/phpunit.xml.dist`.
- [ ] Added/updated tests for the change where applicable.
- [x] Documentation updated where applicable (`docs/`, README).
- [x] No large binaries added outside Git LFS (`src/bin/**` binaries belong in LFS).
- [x] No secrets, credentials, or `.env` files committed.

## How was this tested?

<!-- Describe how you verified the change (commands run, scenarios covered). -->
I verified it with curl command
curl -L -v {streaming_url} -o /dev/null
The subdomain is changed from wildcard to line id properly
## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->

## Summary by Sourcery

Pass the authenticated user ID into streaming URL generation and use it to customize load balancer domains per user.

New Features:
- Allow StreamRedirector::getStreamingURL to accept an optional user ID parameter used for domain selection when building streaming URLs.

Enhancements:
- Derive user ID during stream authentication and propagate it through all streaming URL generation paths so that wildcard domains can be rewritten to user-specific subdomains.