### PR TITLE
Cdn engineer

### DIFF
--- a/docs/en/guides/ucs-integration.md
+++ b/docs/en/guides/ucs-integration.md
@@ -1,0 +1,68 @@
+# UCS Integration — Per-Line Wildcard Subdomains
+
+This feature supports **UCS integration** by giving each client a unique load-balancer subdomain based on their **line ID** when stream redirects are built.
+
+## Overview
+
+When a load-balancer (LB) server uses a wildcard domain and **Serve Random IP / Domain** is enabled, XC_VM replaces the `wildcard.` prefix with the authenticated line ID before redirecting the client.
+
+| Line ID | LB domain (configured) | Redirect domain |
+|--------:|------------------------|-----------------|
+| 10 | `wildcard.example.com` | `10.example.com` |
+| 42 | `wildcard.lb1.com` | `42.lb1.com` |
+
+Each line gets a stable subdomain. UCS (or upstream DNS/proxy) can route `*.example.com` to the correct backend or apply per-line policies.
+
+## Requirements
+
+1. **Load-balancer server** (not the main server) with at least one domain configured under **Domains and IPs**.
+2. **Serve Random IP / Domain** enabled on that LB (`random_ip` checkbox on the server edit page).
+3. A domain entry that starts with **`wildcard.`** (e.g. `wildcard.example.com`).
+4. DNS: a wildcard record for the base zone (e.g. `*.example.com`) pointing at the LB or your UCS edge.
+
+## Setup
+
+1. Open **Servers → Edit** on the target LB server.
+2. Under **Domains and IPs**, add `wildcard.example.com` (use your real zone).
+3. Enable **Serve Random IP / Domain**.
+4. Save the server.
+5. Ensure DNS resolves `{line_id}.example.com` for any line ID you issue (wildcard DNS or UCS automation).
+
+When a client authenticates via `auth.php`, XC_VM reads the line ID from `$rUserInfo['id']` and passes it into the redirect URL builder.
+
+## When It Applies
+
+The substitution runs only when **all** of the following are true:
+
+- The request is authenticated and a line ID is available.
+- **Serve Random IP / Domain** is enabled on the selected LB.
+- The randomly chosen domain from the server’s domain list contains the substring `wildcard.`.
+
+If the client connected using a matching `Host` header, the existing host is kept and wildcard substitution is skipped.
+
+## Example Flow
+
+1. LB server domains: `wildcard.example.com`, `lb2.example.com`
+2. **Serve Random IP / Domain**: on
+3. Client line ID: `10`
+4. Auth picks `wildcard.example.com` from the domain list
+5. Redirect URL host becomes `10.example.com`
+
+## Implementation
+
+Logic lives in `StreamRedirector::getStreamingURL()`:
+
+```php
+// line_id : 10 => wildcard.lb1.com => 10.lb1.com
+if ($rUserID && strpos($rDomain, 'wildcard.') !== false) {
+    $rDomain = str_replace('wildcard.', $rUserID . '.', $rDomain);
+}
+```
+
+Called from `public/stream/auth.php` with `$rUserID = $rUserInfo['id']` for live, VOD, timeshift, and related redirects.
+
+## Notes
+
+- Use the literal prefix **`wildcard.`** in the domain string; only that segment is replaced.
+- The line ID is the internal **lines** table ID (`users.id` in streaming auth), not the username.
+- Wildcard substitution applies to LB redirect URLs only; it does not change playlist or API hostnames unless those paths also call `getStreamingURL()` with a line ID.

--- a/src/public/stream/auth.php
+++ b/src/public/stream/auth.php
@@ -238,6 +238,7 @@ if ($rExtension) {
 	if ($rUserInfo || $rIsHMAC) {
 		$rDeny = false;
 		BruteforceGuard::checkAuthFlood($rUserInfo, $rIP);
+		$rUserID = $rUserInfo['id'] ?? null;
 
 		if (($rServers[SERVER_ID]['enable_proxy'] && !($rProxies[$_SERVER['HTTP_X_IP']] ?? null) && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
 			generateError('PROXY_ACCESS_DENIED');
@@ -448,7 +449,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 				$rStreamInfo = json_decode($rChannelInfo['stream_info'] ?? '', true);
 				$rVideoCodec = ($rStreamInfo['codecs']['video']['codec_name'] ?? 'h264');
 
@@ -482,7 +483,7 @@ if ($rExtension) {
 										$rAdaptiveInfo['redirect_id'] = $rProxyID;
 									}
 
-									$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rAdaptiveInfo['redirect_id'], ($rAdaptiveInfo['originator_id'] ?? null), $rForceHTTP);
+									$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rAdaptiveInfo['redirect_id'], ($rAdaptiveInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 								} else {
 									$rAdaptiveInfo = $rChannelInfo;
 								}
@@ -578,7 +579,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
 
 				if ($rChannelInfo['direct_proxy']) {
 					$rChannelInfo['bitrate'] = (json_decode($rChannelInfo['movie_properties'] ?? '', true)['duration_secs'] ?? 0);
@@ -629,7 +630,7 @@ if ($rExtension) {
 				$rRedirectID = $rProxyID;
 			}
 
-			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rRedirectID, ($rOriginatorID ?: null), $rForceHTTP);
+			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rRedirectID, ($rOriginatorID ?: null), $rForceHTTP, $rUserID);
 			$rStartDate = $rRequest['start'];
 			$rDuration = intval($rRequest['duration']);
 
@@ -708,7 +709,7 @@ if ($rExtension) {
 				$rStreamInfo['info']['vframes_server_id'] = $rProxyID;
 			}
 
-			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rStreamInfo['info']['vframes_server_id'], $rOriginatorID, $rForceHTTP);
+			$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rStreamInfo['info']['vframes_server_id'], $rOriginatorID, $rForceHTTP, $rUserID);
 			$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 			header('Location: ' . $rURL . '/thauth/' . $rToken);
 
@@ -730,7 +731,7 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?: null), $rForceHTTP);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?: null), $rForceHTTP, $rUserID);
 				$rTokenData = array('stream_id' => $rStreamID, 'sub_id' => (intval($rRequest['sid']) ?: 0), 'webvtt' => (intval($rRequest['webvtt']) ?: 0), 'expires' => time() + 5);
 				$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 				header('Location: ' . $rURL . '/subauth/' . $rToken);

--- a/src/streaming/Delivery/StreamRedirector.php
+++ b/src/streaming/Delivery/StreamRedirector.php
@@ -162,7 +162,8 @@ class StreamRedirector {
 		return (!empty($rOutput) ? $rOutput : false);
 	}
 
-	public static function getStreamingURL($rSettings, $rServers, $rServerID = null, $rOriginatorID = null, $rForceHTTP = false) {
+	public static function getStreamingURL($rSettings, $rServers, $rServerID = null, $rOriginatorID = null, $rForceHTTP = false, $rUserID = null) { 
+		//$rUserID is used to redirect clients with different subdomain to the LB server
 		if (!isset($rServerID)) {
 			$rServerID = SERVER_ID;
 		}
@@ -181,6 +182,10 @@ class StreamRedirector {
 		} else {
 			if ($rServers[$rServerID]['random_ip'] && 0 < count($rServers[$rServerID]['domains']['urls'])) {
 				$rDomain = $rServers[$rServerID]['domains']['urls'][array_rand($rServers[$rServerID]['domains']['urls'])];
+				//line_id : 10 => wildcard.lb1.com => 10.lb1.com
+				if($rUserID && strpos($rDomain, 'wildcard.') !== false) { 
+					$rDomain = str_replace('wildcard.', $rUserID . '.', $rDomain);
+				}
 			}
 		}
 		if ($rDomain) {


### PR DESCRIPTION
<!--
  Thanks for contributing to XC_VM!
  Please fill in the sections below and complete the checklist.
-->

## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [x] Code follows the project conventions (see `.github/instructions/php-conventions.instructions.md`).
- [x] `bash tools/php_syntax_check.sh` passes locally.
- [x] Unit tests pass: `php tools/.bin/phpunit.phar -c tests/phpunit.xml.dist`.
- [ ] Added/updated tests for the change where applicable.
- [x] Documentation updated where applicable (`docs/`, README).
- [x] No large binaries added outside Git LFS (`src/bin/**` binaries belong in LFS).
- [x] No secrets, credentials, or `.env` files committed.

## How was this tested?

<!-- Describe how you verified the change (commands run, scenarios covered). -->
I tested it with below command
curl {streaming_url} -L -v -o /dev/null
## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->

## Summary by Sourcery

Pass the authenticated user/line ID into stream redirect URL generation so load balancer wildcard domains can be rewritten per line, and document the UCS integration behavior.

New Features:
- Support per-line wildcard subdomain rewriting on load balancer streaming URLs based on the authenticated line ID.

Enhancements:
- Extend StreamRedirector to accept an optional user ID and substitute it into randomly selected wildcard domains when building streaming URLs.

Documentation:
- Add UCS integration guide describing per-line wildcard subdomains, configuration requirements, and redirect behavior.