### PR TITLE
Refactor/monitor goto

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,6 +49,12 @@ parameters:
 			path: src/Cli/Commands/MonitorCommand.php
 
 		-
+			message: '#^Static method XcVm\\Cli\\Commands\\MonitorCommand\:\:parseFrameRate\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: src/Cli/Commands/MonitorCommand.php
+
+		-
 			message: '#^Call to function is_numeric\(\) with int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -137,112 +137,110 @@ class MonitorCommand implements CommandInterface {
 		// ПРИМЕЧАНИЕ: goto/label — следы обфускации. Рефакторинг запланирован в Phase 14.
 		goto label235;
 		label235:
-		if (true) {
-			if (!(0 < $rPID)) {
-				goto label471;
+		if (!(0 < $rPID)) {
+			goto label471;
+		}
+		$db->close_mysql();
+		$rStartedTime = $rDurationChecked = $rAudioChecked = $rCheckedTime = $rBackupsChecked = time();
+		$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
+		$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
+		$b4015d24aedaf0db = null;
+		goto label592;
+		label592: //while
+		if ((ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist))) {
+			if (!(!empty($rAutoRestart['days']) && !empty($rAutoRestart['at']))) {
+				goto label195;
 			}
-			$db->close_mysql();
-			$rStartedTime = $rDurationChecked = $rAudioChecked = $rCheckedTime = $rBackupsChecked = time();
-			$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
-			$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
-			$b4015d24aedaf0db = null;
-			goto label592;
-			label592: //while
-			if ((ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist))) {
-				if (!(!empty($rAutoRestart['days']) && !empty($rAutoRestart['at']))) {
-					goto label195;
-				}
-				list($rHour, $rMinutes) = explode(':', $rAutoRestart['at']);
-				if (!(in_array(date('l'), $rAutoRestart['days']) && (date('H') == $rHour))) {
-					goto label195;
-				}
-				if (!($rMinutes == date('i'))) {
-					goto label195;
-				}
-				echo "Auto-restart\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
-				$D97a4f098a8d1bf8 = false;
-				goto label1186;
+			list($rHour, $rMinutes) = explode(':', $rAutoRestart['at']);
+			if (!(in_array(date('l'), $rAutoRestart['days']) && (date('H') == $rHour))) {
+				goto label195;
 			}
+			if (!($rMinutes == date('i'))) {
+				goto label195;
+			}
+			echo "Auto-restart\n";
+			StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
+			$D97a4f098a8d1bf8 = false;
 			goto label1186;
-			label195:
-			if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
-				echo "Probe Stream\n";
-				$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-				if (!empty($rSegment)) {
-					if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
-						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
-						goto label1186;
-					}
-					$rLastSegment = $rSegment;
-					$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-					if ((10 < intval($E02429d2ee600884['of_duration']))) {
-						$E02429d2ee600884['of_duration'] = 10;
-					}
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.dur', intval($E02429d2ee600884['of_duration']));
-					if (($rSegmentTime < intval($E02429d2ee600884['of_duration']))) {
-						$rSegmentTime = intval($E02429d2ee600884['of_duration']);
-					}
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
-					$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+		}
+		goto label1186;
+		label195:
+		if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
+			echo "Probe Stream\n";
+			$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+			if (!empty($rSegment)) {
+				if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
+					StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
+					goto label1186;
 				}
-				$rStreamProbe = false;
-				$rDurationChecked = time();
-				if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
+				$rLastSegment = $rSegment;
+				$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+				if ((10 < intval($E02429d2ee600884['of_duration']))) {
+					$E02429d2ee600884['of_duration'] = 10;
 				}
-				if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
+				file_put_contents(STREAMS_PATH . $rStreamID . '_.dur', intval($E02429d2ee600884['of_duration']));
+				if (($rSegmentTime < intval($E02429d2ee600884['of_duration']))) {
+					$rSegmentTime = intval($E02429d2ee600884['of_duration']);
 				}
+				file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
+				$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
 			}
-			if (!(($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check'))) {
-				goto label298;
+			$rStreamProbe = false;
+			$rDurationChecked = time();
+			if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
+				file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
 			}
-			echo "Checking FPS...\n";
-			$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
-			if (!(0 < $d75674a646265e7b)) {
-				goto label1847;
+			if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
+				file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
 			}
-			if (!$b4015d24aedaf0db) {
-				goto label1087;
-			}
-			if (!($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db))) {
-				goto label1847;
-			}
-			echo "FPS dropped below threshold! Break\n";
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
+		}
+		if (!(($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check'))) {
+			goto label298;
+		}
+		echo "Checking FPS...\n";
+		$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
+		if (!(0 < $d75674a646265e7b)) {
+			goto label1847;
+		}
+		if (!$b4015d24aedaf0db) {
+			goto label1087;
+		}
+		if (!($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db))) {
+			goto label1847;
+		}
+		echo "FPS dropped below threshold! Break\n";
+		StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
+		goto label1186;
+		label884:
+		$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
+		if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+			echo "Force new source\n";
+			StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
+			$rForceSource = $rSources[$rForceID];
+			unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
+			$D97a4f098a8d1bf8 = false;
 			goto label1186;
-			label884:
-			$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-			if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
-				echo "Force new source\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
-				$rForceSource = $rSources[$rForceID];
-				unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-				$D97a4f098a8d1bf8 = false;
-				goto label1186;
+		}
+		goto label1631;
+		label1631:
+		unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
+		label496:
+		if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
+			$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
+			$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
+			if (($rSources[$rForceID] != $rCurrentSource)) {
+				$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
+				goto label884;
 			}
 			goto label1631;
-			label1631:
-			unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-			label496:
-			if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
-				$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
-				$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
-				if (($rSources[$rForceID] != $rCurrentSource)) {
-					$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
-					goto label884;
-				}
-				goto label1631;
-			}
-			if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
-				echo "Start Delay\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
-				$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
-			}
-			sleep(1);
-			goto label592;
 		}
+		if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
+			echo "Start Delay\n";
+			StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
+			$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
+		}
+		sleep(1);
+		goto label592;
 		goto label1880;
 		label1:
 		if (!$rStreamInfo['parent_id']) {
@@ -317,32 +315,30 @@ class MonitorCommand implements CommandInterface {
 		$A63c815f93524582 = 20;
 		goto label998;
 		label998:
-		if (true) {
-			echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
-			if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
-				if (file_exists($rPlaylist)) {
-					echo "Playlist exists!\n";
-					goto label1064;
-				}
-				if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
-					echo "Segment exists!\n";
-					$ea6de21e70c530a9 = true;
-					$rChecks = 0;
-					$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
-				}
-				if (($rChecks == $A63c815f93524582)) {
-					echo "Reached max failures\n";
-					$E9d347a502b13abd = true;
-					goto label1064;
-				}
-				$rChecks++;
-				sleep(1);
-				goto label998;
+		echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
+		if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
+			if (file_exists($rPlaylist)) {
+				echo "Playlist exists!\n";
+				goto label1064;
 			}
-			echo "Ffmpeg stopped running\n";
-			$E9d347a502b13abd = true;
-			goto label1064;
+			if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
+				echo "Segment exists!\n";
+				$ea6de21e70c530a9 = true;
+				$rChecks = 0;
+				$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
+			}
+			if (($rChecks == $A63c815f93524582)) {
+				echo "Reached max failures\n";
+				$E9d347a502b13abd = true;
+				goto label1064;
+			}
+			$rChecks++;
+			sleep(1);
+			goto label998;
 		}
+		echo "Ffmpeg stopped running\n";
+		$E9d347a502b13abd = true;
+		goto label1064;
 		goto label1064;
 		label1064:
 		goto label562;

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -139,13 +139,13 @@ class MonitorCommand implements CommandInterface {
 				$db->close_mysql();
 				$rStartedTime = $rDurationChecked = $rAudioChecked = $rCheckedTime = $rBackupsChecked = time();
 				$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
-				$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
-				$b4015d24aedaf0db = null;
+				$rStreamFailed = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
+				$rBaselineFps = null;
 				while (ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist)) {
 					if (self::isAutoRestartDue($rAutoRestart)) {
 						echo "Auto-restart\n";
 						StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
-						$D97a4f098a8d1bf8 = false;
+						$rStreamFailed = false;
 						break;
 					}
 					if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
@@ -157,10 +157,10 @@ class MonitorCommand implements CommandInterface {
 								break;
 							}
 							$rLastSegment = $rSegment;
-							$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-							list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
-							file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
-							$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+							$rProbe = FFprobeRunner::probeStream($rFolder . $rSegment);
+							list($rProbe, $rSegmentTime) = self::persistSegmentDuration($rProbe, $rStreamID, $rSegmentTime);
+							file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($rProbe, JSON_UNESCAPED_UNICODE));
+							$rStreamInfo['stream_info'] = json_encode($rProbe, JSON_UNESCAPED_UNICODE);
 						}
 						$rStreamProbe = false;
 						$rDurationChecked = time();
@@ -173,25 +173,25 @@ class MonitorCommand implements CommandInterface {
 					}
 					if (($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check')) {
 						echo "Checking FPS...\n";
-						$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
-						if (0 < $d75674a646265e7b) {
-							if (!$b4015d24aedaf0db) {
+						$rFps = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
+						if (0 < $rFps) {
+							if (!$rBaselineFps) {
 								if (SettingsManager::getAll()['fps_check_type'] == 1) {
 									$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
 									if (!empty($rSegment)) {
-										$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-										if (isset($E02429d2ee600884['codecs']['video']['avg_frame_rate']) || isset($E02429d2ee600884['codecs']['video']['r_frame_rate'])) {
-											$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
-											$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
-											if (0 < $d75674a646265e7b) {
-												$b4015d24aedaf0db = $d75674a646265e7b;
+										$rProbe = FFprobeRunner::probeStream($rFolder . $rSegment);
+										if (isset($rProbe['codecs']['video']['avg_frame_rate']) || isset($rProbe['codecs']['video']['r_frame_rate'])) {
+											$rFps = $rProbe['codecs']['video']['avg_frame_rate'] ?: $rProbe['codecs']['video']['r_frame_rate'];
+											$rFps = self::parseFrameRate($rFps);
+											if (0 < $rFps) {
+												$rBaselineFps = $rFps;
 											}
 										}
 									}
 								} else {
-									$b4015d24aedaf0db = $d75674a646265e7b;
+									$rBaselineFps = $rFps;
 								}
-							} elseif ($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db)) {
+							} elseif ($rBaselineFps && (($rFps * ($rStreamInfo['fps_threshold'] ?: 100)) < $rBaselineFps)) {
 								echo "FPS dropped below threshold! Break\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
 								break;
@@ -203,8 +203,8 @@ class MonitorCommand implements CommandInterface {
 						echo "Checking audio...\n";
 						$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
 						if (!empty($rSegment)) {
-							$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-							if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
+							$rProbe = FFprobeRunner::probeStream($rFolder . $rSegment);
+							if ((!isset($rProbe['codecs']['audio']) || empty($rProbe['codecs']['audio']))) {
 								echo "Lost audio! Break\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
 								break;
@@ -214,17 +214,17 @@ class MonitorCommand implements CommandInterface {
 							break;
 						}
 					}
-					if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
-						$Fcfb63b23cad3c6e = md5_file($rPlaylist);
-						if ($rMD5 != $Fcfb63b23cad3c6e) {
-							$rMD5 = $Fcfb63b23cad3c6e;
+					if (($rSegmentTime * 6) <= time() - $rCheckedTime) {
+						$rNewMd5 = md5_file($rPlaylist);
+						if ($rMD5 != $rNewMd5) {
+							$rMD5 = $rNewMd5;
 							$rCheckedTime = time();
 							if (SettingsManager::getAll()['encrypt_hls']) {
-							foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
-							if (!file_exists(rtrim($rFile, '.enc'))) {
-							unlink($rFile);
-							}
-							}
+								foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
+									if (!file_exists(rtrim($rFile, '.enc'))) {
+										unlink($rFile);
+									}
+								}
 							}
 							if ((!is_array(json_decode($rStreamInfo['stream_info'], true)) || count(json_decode($rStreamInfo['stream_info'], true)) == 0)) {
 								$rStreamProbe = true;
@@ -244,12 +244,12 @@ class MonitorCommand implements CommandInterface {
 									$rStreamSource = StreamUtils::parseStreamURL($rSource);
 									$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
 									$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-									if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+									if (($rProbe = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
 										echo "Switch priority\n";
 										StreamProcess::streamLog($rStreamID, SERVER_ID, 'PRIORITY_SWITCH', $rSource);
 										$rForceSource = $rSource;
 										$rPrioritySwitch = true;
-										$D97a4f098a8d1bf8 = false;
+										$rStreamFailed = false;
 										break 2;
 									}
 								}
@@ -262,12 +262,12 @@ class MonitorCommand implements CommandInterface {
 						if (($rSources[$rForceID] != $rCurrentSource)) {
 							$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
 							$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-							if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+							if (($rProbe = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
 								echo "Force new source\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
 								$rForceSource = $rSources[$rForceID];
 								unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-								$D97a4f098a8d1bf8 = false;
+								$rStreamFailed = false;
 								break;
 							}
 						}
@@ -280,7 +280,7 @@ class MonitorCommand implements CommandInterface {
 					}
 					sleep(1);
 				}
-				if ($D97a4f098a8d1bf8) {
+				if ($rStreamFailed) {
 					StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_FAILED', $rCurrentSource);
 					echo "Stream failed!\n";
 				}
@@ -302,7 +302,7 @@ class MonitorCommand implements CommandInterface {
 			}
 			if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
 				while (true) {
-					$E9d347a502b13abd = false;
+					$rStartFailed = false;
 					echo "Restarting...\n";
 					shell_exec('rm -f ' . STREAMS_PATH . intval($rStreamID) . '_*');
 					file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
@@ -313,11 +313,11 @@ class MonitorCommand implements CommandInterface {
 					} elseif ((0 < $rStreamInfo['llod']) && $rStreamInfo['on_demand'] && $rFirstRun && $rStreamInfo['type'] != 3) {
 						if ($rStreamInfo['llod'] == 1) {
 							if ($rForceSource) {
-								$Ea84d0933a1ef2f0 = $rForceSource;
+								$rStartSource = $rForceSource;
 							} else {
-								$Ea84d0933a1ef2f0 = json_decode($rStreamInfo['stream_source'], true)[0];
+								$rStartSource = json_decode($rStreamInfo['stream_source'], true)[0];
 							}
-							$rData = StreamProcess::startStream($rStreamID, false, $Ea84d0933a1ef2f0, true);
+							$rData = StreamProcess::startStream($rStreamID, false, $rStartSource, true);
 						} else {
 							if ($rStreamInfo['parent_id']) {
 								$rForceSource = (!is_null(ServerRepository::getAll()[SERVER_ID]['private_url_ip']) && !is_null(ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip']) ? ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip'] : ServerRepository::getAll()[$rStreamInfo['parent_id']]['public_url_ip']) . 'admin/live?stream=' . intval($rStreamID) . '&password=' . urlencode(SettingsManager::getAll()['live_streaming_pass']) . '&extension=ts';
@@ -336,7 +336,7 @@ class MonitorCommand implements CommandInterface {
 						$rData = StreamProcess::startStream($rStreamID, $rTotalCalls < MONITOR_CALLS, $rForceSource);
 					}
 					if ((is_numeric($rData) && ($rData == 0))) {
-						$E9d347a502b13abd = true;
+						$rStartFailed = true;
 						$rMaxFails++;
 						if (((0 < SettingsManager::getAll()['stop_failures']) && ($rMaxFails >= SettingsManager::getAll()['stop_failures']))) {
 							echo "Failure limit reached, exiting.\n";
@@ -351,7 +351,7 @@ class MonitorCommand implements CommandInterface {
 				if (!$rData) {
 					return 0;
 				}
-				if (!$E9d347a502b13abd) {
+				if (!$rStartFailed) {
 					$rPID = intval($rData['main_pid']);
 					if ($rPID) {
 						file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
@@ -378,30 +378,30 @@ class MonitorCommand implements CommandInterface {
 					} else {
 						$rFolder = DELAY_PATH;
 					}
-					$e1bc98ce34937596 = $rFolder . $rStreamID . '_0.ts';
-					$ea6de21e70c530a9 = false;
+					$rFirstSegment = $rFolder . $rStreamID . '_0.ts';
+					$rSegmentSeen = false;
 					$rChecks = 0;
-					$A63c815f93524582 = max(20, min($rSegmentTime * 3, 30));
+					$rMaxChecks = max(20, min($rSegmentTime * 3, 30));
 					while (true) {
-						echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
+						echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $rMaxChecks . "...\n";
 						if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
 							echo "Ffmpeg stopped running\n";
-							$E9d347a502b13abd = true;
+							$rStartFailed = true;
 							break;
 						}
 						if (file_exists($rPlaylist)) {
 							echo "Playlist exists!\n";
 							break;
 						}
-						if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
+						if ((file_exists($rFirstSegment) && !$rSegmentSeen && $rStreamInfo['on_demand'])) {
 							echo "Segment exists!\n";
-							$ea6de21e70c530a9 = true;
+							$rSegmentSeen = true;
 							$rChecks = 0;
 							$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
 						}
-						if (($rChecks == $A63c815f93524582)) {
+						if (($rChecks == $rMaxChecks)) {
 							echo "Reached max failures\n";
-							$E9d347a502b13abd = true;
+							$rStartFailed = true;
 							break;
 						}
 						$rChecks++;
@@ -409,7 +409,7 @@ class MonitorCommand implements CommandInterface {
 					}
 				}
 				SettingsManager::set(SettingsRepository::getAll());
-				if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$E9d347a502b13abd) {
+				if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$rStartFailed) {
 					echo "Started! Probe Stream\n";
 					if ($rFirstRun) {
 						$rFirstRun = false;
@@ -420,10 +420,10 @@ class MonitorCommand implements CommandInterface {
 					$rSegment = $rFolder . StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
 					$rStreamInfo['stream_info'] = null;
 					if (file_exists($rSegment)) {
-						$E02429d2ee600884 = FFprobeRunner::probeStream($rSegment);
-						list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
-						if ($E02429d2ee600884) {
-							$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+						$rProbe = FFprobeRunner::probeStream($rSegment);
+						list($rProbe, $rSegmentTime) = self::persistSegmentDuration($rProbe, $rStreamID, $rSegmentTime);
+						if ($rProbe) {
+							$rStreamInfo['stream_info'] = json_encode($rProbe, JSON_UNESCAPED_UNICODE);
 							$rBitrate = StreamUtils::getStreamBitrate('live', STREAMS_PATH . $rStreamID . '_.m3u8');
 							$rStreamProbe = false;
 							$rDurationChecked = time();
@@ -433,7 +433,7 @@ class MonitorCommand implements CommandInterface {
 					// Defining video/Audio parameters
 					list($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution) = self::resolveStreamCodecMeta($rStreamInfo['stream_info'], SettingsManager::getAll()['player_allow_hevc']);
 
-					if (!$ea6de21e70c530a9 && $rStreamInfo['stream_info'] && $rStreamInfo['on_demand']) {
+					if (!$rSegmentSeen && $rStreamInfo['stream_info'] && $rStreamInfo['on_demand']) {
 						if ($rStreamInfo['stream_info']) {
 							$db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', $rStreamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), time() - $rOffset, $rStreamInfo['server_stream_id']);
 						} else {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -133,376 +133,344 @@ class MonitorCommand implements CommandInterface {
 			}
 		}
 
-		// ── Main monitoring loop (goto-based control flow) ───
-		// ПРИМЕЧАНИЕ: goto/label — следы обфускации. Рефакторинг запланирован в Phase 14.
-		label235:
-		if (!(0 < $rPID)) {
-			goto label471;
-		}
-		$db->close_mysql();
-		$rStartedTime = $rDurationChecked = $rAudioChecked = $rCheckedTime = $rBackupsChecked = time();
-		$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
-		$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
-		$b4015d24aedaf0db = null;
-		while (ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist)) {
-			if (self::isAutoRestartDue($rAutoRestart)) {
-				echo "Auto-restart\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
-				$D97a4f098a8d1bf8 = false;
-				goto label1186;
-			}
-			if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
-				echo "Probe Stream\n";
-				$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-				if (!empty($rSegment)) {
-					if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
-						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
+		// ── Supervisor + monitor loop (restructured from goto state machine) ──
+		while (true) {
+			if (0 < $rPID) {
+				$db->close_mysql();
+				$rStartedTime = $rDurationChecked = $rAudioChecked = $rCheckedTime = $rBackupsChecked = time();
+				$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
+				$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
+				$b4015d24aedaf0db = null;
+				while (ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist)) {
+					if (self::isAutoRestartDue($rAutoRestart)) {
+						echo "Auto-restart\n";
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
+						$D97a4f098a8d1bf8 = false;
 						goto label1186;
 					}
-					$rLastSegment = $rSegment;
-					$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-					list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
-					$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
-				}
-				$rStreamProbe = false;
-				$rDurationChecked = time();
-				if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
-				}
-				if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
-					file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
-				}
-			}
-			if (($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check')) {
-				echo "Checking FPS...\n";
-				$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
-				if (0 < $d75674a646265e7b) {
-					if (!$b4015d24aedaf0db) {
-						if (SettingsManager::getAll()['fps_check_type'] == 1) {
-							$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-							if (!empty($rSegment)) {
-								$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-								if (isset($E02429d2ee600884['codecs']['video']['avg_frame_rate']) || isset($E02429d2ee600884['codecs']['video']['r_frame_rate'])) {
-									$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
-									$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
-									if (0 < $d75674a646265e7b) {
-										$b4015d24aedaf0db = $d75674a646265e7b;
+					if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
+						echo "Probe Stream\n";
+						$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+						if (!empty($rSegment)) {
+							if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
+								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
+								goto label1186;
+							}
+							$rLastSegment = $rSegment;
+							$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+							list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
+							file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
+							$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+						}
+						$rStreamProbe = false;
+						$rDurationChecked = time();
+						if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
+							file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
+						}
+						if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
+							file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
+						}
+					}
+					if (($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check')) {
+						echo "Checking FPS...\n";
+						$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
+						if (0 < $d75674a646265e7b) {
+							if (!$b4015d24aedaf0db) {
+								if (SettingsManager::getAll()['fps_check_type'] == 1) {
+									$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+									if (!empty($rSegment)) {
+										$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+										if (isset($E02429d2ee600884['codecs']['video']['avg_frame_rate']) || isset($E02429d2ee600884['codecs']['video']['r_frame_rate'])) {
+											$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
+											$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
+											if (0 < $d75674a646265e7b) {
+												$b4015d24aedaf0db = $d75674a646265e7b;
+											}
+										}
+									}
+								} else {
+									$b4015d24aedaf0db = $d75674a646265e7b;
+								}
+							} elseif ($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db)) {
+								echo "FPS dropped below threshold! Break\n";
+								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
+								goto label1186;
+							}
+						}
+						unlink(STREAMS_PATH . $rStreamID . '_.progress_check');
+					}
+					if ((SettingsManager::getAll()['audio_restart_loss'] == 1) && (300 < (time() - $rAudioChecked))) {
+						echo "Checking audio...\n";
+						$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+						if (!empty($rSegment)) {
+							$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+							if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
+								echo "Lost audio! Break\n";
+								StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
+								goto label1186;
+							}
+							$rAudioChecked = time();
+						} else {
+							goto label1186;
+						}
+					}
+					if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
+						$Fcfb63b23cad3c6e = md5_file($rPlaylist);
+						if ($rMD5 != $Fcfb63b23cad3c6e) {
+							$rMD5 = $Fcfb63b23cad3c6e;
+							$rCheckedTime = time();
+							if (SettingsManager::getAll()['encrypt_hls']) {
+							foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
+							if (!file_exists(rtrim($rFile, '.enc'))) {
+							unlink($rFile);
+							}
+							}
+							}
+							if ((!is_array(json_decode($rStreamInfo['stream_info'], true)) || count(json_decode($rStreamInfo['stream_info'], true)) == 0)) {
+								$rStreamProbe = true;
+							}
+							$rCheckedTime = time();
+						} else {
+							goto label1186;
+						}
+					}
+					if (((SettingsManager::getAll()['priority_backup'] == 1) && (1 < count($rSources)) && ($rParentID == 0) && (300 < (time() - $rBackupsChecked)))) {
+						echo "Checking backups...\n";
+						$rBackupsChecked = time();
+						$rKey = array_search($rCurrentSource, $rSources);
+						if ((!is_numeric($rKey) || (0 < $rKey))) {
+							foreach ($rSources as $rSource) {
+								if (!(($rSource == $rCurrentSource) || ($rSource == $rForceSource))) {
+									$rStreamSource = StreamUtils::parseStreamURL($rSource);
+									$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
+									$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
+									if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+										echo "Switch priority\n";
+										StreamProcess::streamLog($rStreamID, SERVER_ID, 'PRIORITY_SWITCH', $rSource);
+										$rForceSource = $rSource;
+										$rPrioritySwitch = true;
+										$D97a4f098a8d1bf8 = false;
+										goto label1186;
 									}
 								}
 							}
-						} else {
-							$b4015d24aedaf0db = $d75674a646265e7b;
 						}
-					} elseif ($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db)) {
-						echo "FPS dropped below threshold! Break\n";
-						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
-						goto label1186;
 					}
-				}
-				unlink(STREAMS_PATH . $rStreamID . '_.progress_check');
-			}
-			if ((SettingsManager::getAll()['audio_restart_loss'] == 1) && (300 < (time() - $rAudioChecked))) {
-				echo "Checking audio...\n";
-				$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-				if (!empty($rSegment)) {
-					$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-					if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
-						echo "Lost audio! Break\n";
-						StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
-						goto label1186;
-					}
-					$rAudioChecked = time();
-				} else {
-					goto label1186;
-				}
-			}
-			if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
-				$Fcfb63b23cad3c6e = md5_file($rPlaylist);
-				if ($rMD5 != $Fcfb63b23cad3c6e) {
-					$rMD5 = $Fcfb63b23cad3c6e;
-					$rCheckedTime = time();
-					if (SettingsManager::getAll()['encrypt_hls']) {
-					foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
-					if (!file_exists(rtrim($rFile, '.enc'))) {
-					unlink($rFile);
-					}
-					}
-					}
-					if ((!is_array(json_decode($rStreamInfo['stream_info'], true)) || count(json_decode($rStreamInfo['stream_info'], true)) == 0)) {
-						$rStreamProbe = true;
-					}
-					$rCheckedTime = time();
-				} else {
-					goto label1186;
-				}
-			}
-			if (((SettingsManager::getAll()['priority_backup'] == 1) && (1 < count($rSources)) && ($rParentID == 0) && (300 < (time() - $rBackupsChecked)))) {
-				echo "Checking backups...\n";
-				$rBackupsChecked = time();
-				$rKey = array_search($rCurrentSource, $rSources);
-				if ((!is_numeric($rKey) || (0 < $rKey))) {
-					foreach ($rSources as $rSource) {
-						if (!(($rSource == $rCurrentSource) || ($rSource == $rForceSource))) {
-							$rStreamSource = StreamUtils::parseStreamURL($rSource);
+					if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
+						$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
+						$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
+						if (($rSources[$rForceID] != $rCurrentSource)) {
 							$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
 							$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
 							if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
-								echo "Switch priority\n";
-								StreamProcess::streamLog($rStreamID, SERVER_ID, 'PRIORITY_SWITCH', $rSource);
-								$rForceSource = $rSource;
-								$rPrioritySwitch = true;
+								echo "Force new source\n";
+								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
+								$rForceSource = $rSources[$rForceID];
+								unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
 								$D97a4f098a8d1bf8 = false;
 								goto label1186;
 							}
 						}
-					}
-				}
-			}
-			if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
-				$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
-				$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
-				if (($rSources[$rForceID] != $rCurrentSource)) {
-					$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
-					$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-					if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
-						echo "Force new source\n";
-						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
-						$rForceSource = $rSources[$rForceID];
 						unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-						$D97a4f098a8d1bf8 = false;
-						goto label1186;
 					}
+					if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
+						echo "Start Delay\n";
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
+						$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
+					}
+					sleep(1);
 				}
-				unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
+				label1186:
+				if ($D97a4f098a8d1bf8) {
+					StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_FAILED', $rCurrentSource);
+					echo "Stream failed!\n";
+				}
+				$db->db_connect();
 			}
-			if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
-				echo "Start Delay\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
-				$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
+			if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
+				echo "Killing stream...\n";
+				if ((is_numeric($rPID) && (0 < $rPID))) {
+					shell_exec('kill -9 ' . intval($rPID));
+				}
+				usleep(50000);
 			}
-			sleep(1);
-		}
-		goto label1186;
-		label1:
-		if (!$rStreamInfo['parent_id']) {
-			goto label49;
-		}
-		$rForceSource = (!is_null(ServerRepository::getAll()[SERVER_ID]['private_url_ip']) && !is_null(ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip']) ? ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip'] : ServerRepository::getAll()[$rStreamInfo['parent_id']]['public_url_ip']) . 'admin/live?stream=' . intval($rStreamID) . '&password=' . urlencode(SettingsManager::getAll()['live_streaming_pass']) . '&extension=ts';
-		label49:
-		$rData = StreamProcess::startLLOD($rStreamID, $rStreamInfo, $rStreamInfo['parent_id'] ? array() : $rStreamArguments, $rForceSource);
-		goto label644;
-		label1512:
-		if ($rForceSource) {
-			$Ea84d0933a1ef2f0 = $rForceSource;
-		} else {
-			$Ea84d0933a1ef2f0 = json_decode($rStreamInfo['stream_source'], true)[0];
-		}
-		$rData = StreamProcess::startStream($rStreamID, false, $Ea84d0933a1ef2f0, true);
-		label644:
-		goto label1131;
-		label1127:
-		$rData = StreamProcess::startLoopback($rStreamID);
-		label1131:
-		if ((is_numeric($rData) && ($rData == 0))) {
-			$E9d347a502b13abd = true;
-			$rMaxFails++;
-			if (((0 < SettingsManager::getAll()['stop_failures']) && ($rMaxFails >= SettingsManager::getAll()['stop_failures']))) {
-				echo "Failure limit reached, exiting.\n";
-				return 0;
+			if (ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID)) {
+				echo "Killing stream delay...\n";
+				if ((is_numeric($rDelayPID) && (0 < $rDelayPID))) {
+					shell_exec('kill -9 ' . intval($rDelayPID));
+				}
+				usleep(50000);
 			}
-			echo 'Stream start failed (attempt ' . $rMaxFails . '). Sleeping ' . SettingsManager::getAll()['stream_fail_sleep'] . " seconds...\n";
-			sleep(SettingsManager::getAll()['stream_fail_sleep']);
-			goto label76;
-		}
-		if (!$rData) {
-			return 0;
-		}
-		if ($E9d347a502b13abd) {
-			goto label562;
-		}
-		$rPID = intval($rData['main_pid']);
-		if ($rPID) {
-			file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
-		}
-		$rPlaylist = $rData['playlist'];
-		$rDelay = $rData['delay_enabled'];
-		$rStreamInfo['delay_available_at'] = $rData['delay_start_at'];
-		$rParentID = $rData['parent_id'];
-		if (0 >= $rParentID) {
-			$rCurrentSource = trim($rData['stream_source'], '\'"');
-		} else {
-			$rCurrentSource = 'Loopback: #' . $rParentID;
-		}
-		$rOffset = $rData['offset'];
-		$rStreamProbe = true;
-		echo "Stream started\n";
-		echo $rCurrentSource . "\n";
-		if ($rPrioritySwitch) {
-			$rForceSource = null;
-			$rPrioritySwitch = false;
-		}
-		if (!$rDelay) {
-			$rFolder = STREAMS_PATH;
-		} else {
-			$rFolder = DELAY_PATH;
-		}
-		$e1bc98ce34937596 = $rFolder . $rStreamID . '_0.ts';
-		$ea6de21e70c530a9 = false;
-		$rChecks = 0;
-		$A63c815f93524582 = max(20, min($rSegmentTime * 3, 30));
-		while (true) {
-			echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
 			if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
-				echo "Ffmpeg stopped running\n";
-				$E9d347a502b13abd = true;
-				break;
-			}
-			if (file_exists($rPlaylist)) {
-				echo "Playlist exists!\n";
-				break;
-			}
-			if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
-				echo "Segment exists!\n";
-				$ea6de21e70c530a9 = true;
-				$rChecks = 0;
-				$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
-			}
-			if (($rChecks == $A63c815f93524582)) {
-				echo "Reached max failures\n";
-				$E9d347a502b13abd = true;
-				break;
-			}
-			$rChecks++;
-			sleep(1);
-		}
-		label562:
-		SettingsManager::set(SettingsRepository::getAll());
-		if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$E9d347a502b13abd) {
-			echo "Started! Probe Stream\n";
-			if ($rFirstRun) {
-				$rFirstRun = false;
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_START', $rCurrentSource);
-			} else {
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_RESTART', $rCurrentSource);
-			}
-			$rSegment = $rFolder . StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-			$rStreamInfo['stream_info'] = null;
-			if (file_exists($rSegment)) {
-				$E02429d2ee600884 = FFprobeRunner::probeStream($rSegment);
-				list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
-				if ($E02429d2ee600884) {
-					$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
-					$rBitrate = StreamUtils::getStreamBitrate('live', STREAMS_PATH . $rStreamID . '_.m3u8');
-					$rStreamProbe = false;
-					$rDurationChecked = time();
+				while (true) {
+					$E9d347a502b13abd = false;
+					echo "Restarting...\n";
+					shell_exec('rm -f ' . STREAMS_PATH . intval($rStreamID) . '_*');
+					file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
+					$rOffset = 0;
+					$rTotalCalls++;
+					if ((0 < $rStreamInfo['parent_id']) && SettingsManager::getAll()['php_loopback']) {
+						$rData = StreamProcess::startLoopback($rStreamID);
+					} elseif ((0 < $rStreamInfo['llod']) && $rStreamInfo['on_demand'] && $rFirstRun && $rStreamInfo['type'] != 3) {
+						if ($rStreamInfo['llod'] == 1) {
+							if ($rForceSource) {
+								$Ea84d0933a1ef2f0 = $rForceSource;
+							} else {
+								$Ea84d0933a1ef2f0 = json_decode($rStreamInfo['stream_source'], true)[0];
+							}
+							$rData = StreamProcess::startStream($rStreamID, false, $Ea84d0933a1ef2f0, true);
+						} else {
+							if ($rStreamInfo['parent_id']) {
+								$rForceSource = (!is_null(ServerRepository::getAll()[SERVER_ID]['private_url_ip']) && !is_null(ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip']) ? ServerRepository::getAll()[$rStreamInfo['parent_id']]['private_url_ip'] : ServerRepository::getAll()[$rStreamInfo['parent_id']]['public_url_ip']) . 'admin/live?stream=' . intval($rStreamID) . '&password=' . urlencode(SettingsManager::getAll()['live_streaming_pass']) . '&extension=ts';
+							}
+							$rData = StreamProcess::startLLOD($rStreamID, $rStreamInfo, $rStreamInfo['parent_id'] ? array() : $rStreamArguments, $rForceSource);
+						}
+					} elseif ($rStreamInfo['type'] == 3) {
+						if ((0 < $rPID) && !$rStreamInfo['parent_id'] && (0 < $rStreamInfo['stream_started'])) {
+							$rCCInfo = json_decode($rStreamInfo['cc_info'], true);
+							if (($rCCInfo && ((time() - $rStreamInfo['stream_started']) < (intval($rCCInfo[count($rCCInfo) - 1]['finish']) * 0.95)))) {
+								$rOffset = time() - $rStreamInfo['stream_started'];
+							}
+						}
+						$rData = StreamProcess::startStream($rStreamID, false, $rForceSource, false, $rOffset);
+					} else {
+						$rData = StreamProcess::startStream($rStreamID, $rTotalCalls < MONITOR_CALLS, $rForceSource);
+					}
+					if ((is_numeric($rData) && ($rData == 0))) {
+						$E9d347a502b13abd = true;
+						$rMaxFails++;
+						if (((0 < SettingsManager::getAll()['stop_failures']) && ($rMaxFails >= SettingsManager::getAll()['stop_failures']))) {
+							echo "Failure limit reached, exiting.\n";
+							return 0;
+						}
+						echo 'Stream start failed (attempt ' . $rMaxFails . '). Sleeping ' . SettingsManager::getAll()['stream_fail_sleep'] . " seconds...\n";
+						sleep(SettingsManager::getAll()['stream_fail_sleep']);
+						continue;
+					}
+					break;
 				}
-			}
-
-			// Defining video/Audio parameters
-			list($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution) = self::resolveStreamCodecMeta($rStreamInfo['stream_info'], SettingsManager::getAll()['player_allow_hevc']);
-
-			if (!$ea6de21e70c530a9 && $rStreamInfo['stream_info'] && $rStreamInfo['on_demand']) {
-				if ($rStreamInfo['stream_info']) {
-					$db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', $rStreamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), time() - $rOffset, $rStreamInfo['server_stream_id']);
-				} else {
-					$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_info` = NULL, `compatible` = 0, `audio_codec` = NULL, `video_codec` = NULL, `resolution` = NULL, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
+				if (!$rData) {
+					return 0;
 				}
-			} else {
-				$db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0 WHERE `server_stream_id` = ?', $rStreamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), $rStreamInfo['server_stream_id']);
-			}
-			if (SettingsManager::getAll()['enable_cache']) {
-				StreamProcess::updateStream($rStreamID);
-			}
-			echo "End start process\n";
-			goto label554;
-		}
-		echo "Stream start failed...\n";
-		if (($rParentID == 0)) {
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_START_FAIL', $rCurrentSource);
-		}
-		if ((is_numeric($rPID) && (0 < $rPID) && ProcessManager::isStreamRunning($rPID, $rStreamID))) {
-			shell_exec('kill -9 ' . intval($rPID));
-		}
-		$db->query('UPDATE `streams_servers` SET `pid` = null, `stream_status` = 1 WHERE `server_stream_id` = ?;', $rStreamInfo['server_stream_id']);
-		if (SettingsManager::getAll()['enable_cache']) {
-			StreamProcess::updateStream($rStreamID);
-		}
-		echo 'Sleep for ' . SettingsManager::getAll()['stream_fail_sleep'] . " seconds...";
-		sleep(SettingsManager::getAll()['stream_fail_sleep']);
-		if (!(SettingsManager::getAll()['on_demand_failure_exit'] && $rStreamInfo['on_demand'])) {
-			goto label554;
-		}
-		echo "On-demand failed to run!\n";
-		return 0;
-		label1186:
-		if ($D97a4f098a8d1bf8) {
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_FAILED', $rCurrentSource);
-			echo "Stream failed!\n";
-		}
-		$db->db_connect();
-		label471:
-		if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
-			echo "Killing stream...\n";
-			if ((is_numeric($rPID) && (0 < $rPID))) {
-				shell_exec('kill -9 ' . intval($rPID));
-			}
-			usleep(50000);
-		}
-		if (ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID)) {
-			echo "Killing stream delay...\n";
-			if ((is_numeric($rDelayPID) && (0 < $rDelayPID))) {
-				shell_exec('kill -9 ' . intval($rDelayPID));
-			}
-			usleep(50000);
-		}
-		goto label76;
-		label554:
-		if ((MONITOR_CALLS <= $rTotalCalls)) {
-			$rTotalCalls = 0;
-		}
-		label76:
-		if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
-			$E9d347a502b13abd = false;
-			echo "Restarting...\n";
-			shell_exec('rm -f ' . STREAMS_PATH . intval($rStreamID) . '_*');
-			file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
-			$rOffset = 0;
-			$rTotalCalls++;
-			if ((0 < $rStreamInfo['parent_id']) && SettingsManager::getAll()['php_loopback']) {
-				goto label1127;
-			}
-			// LLOD/on-demand shortcut is for regular live streams only: created
-			// channels (type 3) must always start through the concat playlist
-			// path below — LLOD cannot consume raw "s:<server>:<path>" sources.
-			if ((0 < $rStreamInfo['llod']) && $rStreamInfo['on_demand'] && $rFirstRun && $rStreamInfo['type'] != 3) {
-				goto label933;
-			}
-			if ($rStreamInfo['type'] == 3) {
-				if (((0 < $rPID) && !$rStreamInfo['parent_id'] && (0 < $rStreamInfo['stream_started']))) {
-					$rCCInfo = json_decode($rStreamInfo['cc_info'], true);
-					if (($rCCInfo && ((time() - $rStreamInfo['stream_started']) < (intval($rCCInfo[count($rCCInfo) - 1]['finish']) * 0.95)))) {
-						$rOffset = time() - $rStreamInfo['stream_started'];
+				if (!$E9d347a502b13abd) {
+					$rPID = intval($rData['main_pid']);
+					if ($rPID) {
+						file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
+					}
+					$rPlaylist = $rData['playlist'];
+					$rDelay = $rData['delay_enabled'];
+					$rStreamInfo['delay_available_at'] = $rData['delay_start_at'];
+					$rParentID = $rData['parent_id'];
+					if (0 >= $rParentID) {
+						$rCurrentSource = trim($rData['stream_source'], '\'"');
+					} else {
+						$rCurrentSource = 'Loopback: #' . $rParentID;
+					}
+					$rOffset = $rData['offset'];
+					$rStreamProbe = true;
+					echo "Stream started\n";
+					echo $rCurrentSource . "\n";
+					if ($rPrioritySwitch) {
+						$rForceSource = null;
+						$rPrioritySwitch = false;
+					}
+					if (!$rDelay) {
+						$rFolder = STREAMS_PATH;
+					} else {
+						$rFolder = DELAY_PATH;
+					}
+					$e1bc98ce34937596 = $rFolder . $rStreamID . '_0.ts';
+					$ea6de21e70c530a9 = false;
+					$rChecks = 0;
+					$A63c815f93524582 = max(20, min($rSegmentTime * 3, 30));
+					while (true) {
+						echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
+						if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
+							echo "Ffmpeg stopped running\n";
+							$E9d347a502b13abd = true;
+							break;
+						}
+						if (file_exists($rPlaylist)) {
+							echo "Playlist exists!\n";
+							break;
+						}
+						if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
+							echo "Segment exists!\n";
+							$ea6de21e70c530a9 = true;
+							$rChecks = 0;
+							$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
+						}
+						if (($rChecks == $A63c815f93524582)) {
+							echo "Reached max failures\n";
+							$E9d347a502b13abd = true;
+							break;
+						}
+						$rChecks++;
+						sleep(1);
 					}
 				}
-				$rData = StreamProcess::startStream($rStreamID, false, $rForceSource, false, $rOffset);
-				// Without this jump execution would fall through into label933
-				// and start LLOD/a second ffmpeg on top of the stream launched
-				// above (the non-type-3 branch below has the same jump).
-				goto label644;
-				label933:
-				if ($rStreamInfo['llod'] == 1) {
-					goto label1512;
-				}
-				goto label1;
-			}
-			$rData = StreamProcess::startStream($rStreamID, $rTotalCalls < MONITOR_CALLS, $rForceSource);
-			goto label644;
-		}
-		goto label235;
-		label1880:
+				SettingsManager::set(SettingsRepository::getAll());
+				if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$E9d347a502b13abd) {
+					echo "Started! Probe Stream\n";
+					if ($rFirstRun) {
+						$rFirstRun = false;
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_START', $rCurrentSource);
+					} else {
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_RESTART', $rCurrentSource);
+					}
+					$rSegment = $rFolder . StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+					$rStreamInfo['stream_info'] = null;
+					if (file_exists($rSegment)) {
+						$E02429d2ee600884 = FFprobeRunner::probeStream($rSegment);
+						list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
+						if ($E02429d2ee600884) {
+							$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+							$rBitrate = StreamUtils::getStreamBitrate('live', STREAMS_PATH . $rStreamID . '_.m3u8');
+							$rStreamProbe = false;
+							$rDurationChecked = time();
+						}
+					}
 
-		return 0;
+					// Defining video/Audio parameters
+					list($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution) = self::resolveStreamCodecMeta($rStreamInfo['stream_info'], SettingsManager::getAll()['player_allow_hevc']);
+
+					if (!$ea6de21e70c530a9 && $rStreamInfo['stream_info'] && $rStreamInfo['on_demand']) {
+						if ($rStreamInfo['stream_info']) {
+							$db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0, `stream_started` = ? WHERE `server_stream_id` = ?', $rStreamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), time() - $rOffset, $rStreamInfo['server_stream_id']);
+						} else {
+							$db->query('UPDATE `streams_servers` SET `stream_status` = 0, `stream_info` = NULL, `compatible` = 0, `audio_codec` = NULL, `video_codec` = NULL, `resolution` = NULL, `stream_started` = ? WHERE `server_stream_id` = ?', time() - $rOffset, $rStreamInfo['server_stream_id']);
+						}
+					} else {
+						$db->query('UPDATE `streams_servers` SET `stream_info` = ?, `compatible` = ?, `audio_codec` = ?, `video_codec` = ?, `resolution` = ?, `bitrate` = ?, `stream_status` = 0 WHERE `server_stream_id` = ?', $rStreamInfo['stream_info'], $rCompatible, $rAudioCodec, $rVideoCodec, $rResolution, intval($rBitrate), $rStreamInfo['server_stream_id']);
+					}
+					if (SettingsManager::getAll()['enable_cache']) {
+						StreamProcess::updateStream($rStreamID);
+					}
+					echo "End start process\n";
+				} else {
+					echo "Stream start failed...\n";
+					if (($rParentID == 0)) {
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_START_FAIL', $rCurrentSource);
+					}
+					if ((is_numeric($rPID) && (0 < $rPID) && ProcessManager::isStreamRunning($rPID, $rStreamID))) {
+						shell_exec('kill -9 ' . intval($rPID));
+					}
+					$db->query('UPDATE `streams_servers` SET `pid` = null, `stream_status` = 1 WHERE `server_stream_id` = ?;', $rStreamInfo['server_stream_id']);
+					if (SettingsManager::getAll()['enable_cache']) {
+						StreamProcess::updateStream($rStreamID);
+					}
+					echo 'Sleep for ' . SettingsManager::getAll()['stream_fail_sleep'] . " seconds...";
+					sleep(SettingsManager::getAll()['stream_fail_sleep']);
+					if (SettingsManager::getAll()['on_demand_failure_exit'] && $rStreamInfo['on_demand']) {
+						echo "On-demand failed to run!\n";
+						return 0;
+					}
+				}
+				if ((MONITOR_CALLS <= $rTotalCalls)) {
+					$rTotalCalls = 0;
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -135,7 +135,6 @@ class MonitorCommand implements CommandInterface {
 
 		// ── Main monitoring loop (goto-based control flow) ───
 		// ПРИМЕЧАНИЕ: goto/label — следы обфускации. Рефакторинг запланирован в Phase 14.
-		goto label235;
 		label235:
 		if (!(0 < $rPID)) {
 			goto label471;
@@ -145,7 +144,6 @@ class MonitorCommand implements CommandInterface {
 		$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
 		$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
 		$b4015d24aedaf0db = null;
-		goto label592;
 		label592: //while
 		if ((ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist))) {
 			if (!(!empty($rAutoRestart['days']) && !empty($rAutoRestart['at']))) {
@@ -221,7 +219,6 @@ class MonitorCommand implements CommandInterface {
 			$D97a4f098a8d1bf8 = false;
 			goto label1186;
 		}
-		goto label1631;
 		label1631:
 		unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
 		label496:
@@ -241,7 +238,6 @@ class MonitorCommand implements CommandInterface {
 		}
 		sleep(1);
 		goto label592;
-		goto label1880;
 		label1:
 		if (!$rStreamInfo['parent_id']) {
 			goto label49;
@@ -313,7 +309,6 @@ class MonitorCommand implements CommandInterface {
 			goto label998;
 		}
 		$A63c815f93524582 = 20;
-		goto label998;
 		label998:
 		echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
 		if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
@@ -338,10 +333,7 @@ class MonitorCommand implements CommandInterface {
 		}
 		echo "Ffmpeg stopped running\n";
 		$E9d347a502b13abd = true;
-		goto label1064;
-		goto label1064;
 		label1064:
-		goto label562;
 		label562:
 		SettingsManager::set(SettingsRepository::getAll());
 		if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$E9d347a502b13abd) {
@@ -426,7 +418,6 @@ class MonitorCommand implements CommandInterface {
 			echo "Stream failed!\n";
 		}
 		$db->db_connect();
-		goto label471;
 		label471:
 		if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
 			echo "Killing stream...\n";
@@ -447,7 +438,6 @@ class MonitorCommand implements CommandInterface {
 		if ((MONITOR_CALLS <= $rTotalCalls)) {
 			$rTotalCalls = 0;
 		}
-		goto label76;
 		label76:
 		if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
 			$E9d347a502b13abd = false;
@@ -503,7 +493,6 @@ class MonitorCommand implements CommandInterface {
 			goto label1847;
 		}
 		$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
-		goto label768;
 		label768:
 		$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
 		if (0 < $d75674a646265e7b) {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -291,17 +291,17 @@ class MonitorCommand implements CommandInterface {
 		$e1bc98ce34937596 = $rFolder . $rStreamID . '_0.ts';
 		$ea6de21e70c530a9 = false;
 		$rChecks = 0;
-		$A63c815f93524582 = (($rSegmentTime * 3) <= 30 ? $rSegmentTime * 3 : 30);
-		if (!($A63c815f93524582 < 20)) {
-			goto label998;
-		}
-		$A63c815f93524582 = 20;
-		label998:
-		echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
-		if (ProcessManager::isStreamRunning($rPID, $rStreamID)) {
+		$A63c815f93524582 = max(20, min($rSegmentTime * 3, 30));
+		while (true) {
+			echo 'Checking for playlist ' . ($rChecks + 1) . '/' . $A63c815f93524582 . "...\n";
+			if (!ProcessManager::isStreamRunning($rPID, $rStreamID)) {
+				echo "Ffmpeg stopped running\n";
+				$E9d347a502b13abd = true;
+				break;
+			}
 			if (file_exists($rPlaylist)) {
 				echo "Playlist exists!\n";
-				goto label1064;
+				break;
 			}
 			if ((file_exists($e1bc98ce34937596) && !$ea6de21e70c530a9 && $rStreamInfo['on_demand'])) {
 				echo "Segment exists!\n";
@@ -312,15 +312,11 @@ class MonitorCommand implements CommandInterface {
 			if (($rChecks == $A63c815f93524582)) {
 				echo "Reached max failures\n";
 				$E9d347a502b13abd = true;
-				goto label1064;
+				break;
 			}
 			$rChecks++;
 			sleep(1);
-			goto label998;
 		}
-		echo "Ffmpeg stopped running\n";
-		$E9d347a502b13abd = true;
-		label1064:
 		label562:
 		SettingsManager::set(SettingsRepository::getAll());
 		if (ProcessManager::isStreamRunning($rPID, $rStreamID) && !$E9d347a502b13abd) {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -146,20 +146,13 @@ class MonitorCommand implements CommandInterface {
 		$b4015d24aedaf0db = null;
 		label592: //while
 		if ((ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist))) {
-			if (!(!empty($rAutoRestart['days']) && !empty($rAutoRestart['at']))) {
-				goto label195;
+			if (self::isAutoRestartDue($rAutoRestart)) {
+				echo "Auto-restart\n";
+				StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
+				$D97a4f098a8d1bf8 = false;
+				goto label1186;
 			}
-			list($rHour, $rMinutes) = explode(':', $rAutoRestart['at']);
-			if (!(in_array(date('l'), $rAutoRestart['days']) && (date('H') == $rHour))) {
-				goto label195;
-			}
-			if (!($rMinutes == date('i'))) {
-				goto label195;
-			}
-			echo "Auto-restart\n";
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
-			$D97a4f098a8d1bf8 = false;
-			goto label1186;
+			goto label195;
 		}
 		goto label1186;
 		label195:
@@ -583,6 +576,26 @@ class MonitorCommand implements CommandInterface {
 			return $rDen != 0.0 ? (float) ($rNum / $rDen) : 0.0;
 		}
 		return (float) $rRate;
+	}
+
+	/**
+	 * Whether a stream's scheduled auto-restart is due now: the config carries
+	 * days + a HH:MM time, and the current weekday/hour/minute all match.
+	 * Extracted from the label195 goto chain.
+	 *
+	 * @param mixed    $rAutoRestart Decoded auto_restart config (['days'=>[...],'at'=>'HH:MM']).
+	 * @param int|null $rNow         Timestamp to test against (defaults to now).
+	 * @return bool
+	 */
+	private static function isAutoRestartDue($rAutoRestart, $rNow = null): bool {
+		if (empty($rAutoRestart['days']) || empty($rAutoRestart['at'])) {
+			return false;
+		}
+		$rNow = $rNow ?? time();
+		list($rHour, $rMinutes) = explode(':', $rAutoRestart['at']);
+		return in_array(date('l', $rNow), $rAutoRestart['days'])
+			&& date('H', $rNow) == $rHour
+			&& date('i', $rNow) == $rMinutes;
 	}
 
 	private function checkRunning(int $rStreamID): void {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -14,13 +14,16 @@ use XcVm\Domain\Stream\StreamSorter;
 use XcVm\Streaming\Codec\FFprobeRunner;
 
 /**
- * Мониторинг одного стрима (из cli/monitor.php).
+ * `monitor <stream_id> [restart]` — the per-stream watchdog.
  *
- * Запуск: php console.php monitor <stream_id> [restart]
+ * Runs one long-lived supervisor loop per stream (as the `xc_vm` user): it
+ * (re)starts the stream's ffmpeg, waits for the HLS playlist to appear, probes
+ * the first segment for codec/duration metadata, then watches the running
+ * stream and restarts it on ffmpeg death, an FPS drop, audio loss, a stale
+ * playlist, a scheduled auto-restart, or a priority/forced source switch.
  *
- * ВНИМАНИЕ: Этот файл содержит goto/label flow-control — следы обфускации.
- * Планируется рефакторинг в Phase 14 (→ domain/Stream/StreamMonitor.php).
- * На данном этапе логика перенесена as-is.
+ * Once an obfuscated goto/label state machine; since untangled into structured
+ * while-loops backed by the small probe/codec/fps helpers at the bottom.
  *
  * @package XC_VM_CLI_Commands
  * @author  Divarion_D <https://github.com/Divarion-D>
@@ -31,14 +34,27 @@ use XcVm\Streaming\Codec\FFprobeRunner;
 
 class MonitorCommand implements CommandInterface {
 
+	/** {@inheritDoc} */
 	public function getName(): string {
 		return 'monitor';
 	}
 
+	/** {@inheritDoc} */
 	public function getDescription(): string {
 		return 'Monitor stream by ID (start/restart/track)';
 	}
 
+	/**
+	 * Supervise stream `$rArgs[0]`: load its config, then loop forever —
+	 * start/restart the ffmpeg process, wait for its playlist, probe it, and
+	 * monitor health — until an exit condition (failure limit, missing stream,
+	 * on-demand give-up) returns.
+	 *
+	 * Must run as the `xc_vm` user.
+	 *
+	 * @param array $rArgs [0 => stream id, 1 => optional truthy "restart" flag].
+	 * @return int Exit code: 0 = clean stop, 1 = wrong user.
+	 */
 	public function execute(array $rArgs): int {
 		if (posix_getpwuid(posix_geteuid())['name'] != 'xc_vm') {
 			echo "Please run as \XC_VM!\n";
@@ -474,7 +490,7 @@ class MonitorCommand implements CommandInterface {
 
 	/**
 	 * Parse an ffprobe frame-rate field ("30", "30000/1001", "25/1") into fps.
-	 * Extracted from the FPS-check goto cluster (label768/780/1047/1052/1057).
+	 * Used by the in-loop FPS-drop check.
 	 *
 	 * @param mixed $rRate Raw avg_frame_rate / r_frame_rate value.
 	 * @return float Frames per second; 0.0 for empty/zero/malformed input.
@@ -491,7 +507,6 @@ class MonitorCommand implements CommandInterface {
 	/**
 	 * Whether a stream's scheduled auto-restart is due now: the config carries
 	 * days + a HH:MM time, and the current weekday/hour/minute all match.
-	 * Extracted from the label195 goto chain.
 	 *
 	 * @param mixed    $rAutoRestart Decoded auto_restart config (['days'=>[...],'at'=>'HH:MM']).
 	 * @param int|null $rNow         Timestamp to test against (defaults to now).
@@ -511,7 +526,7 @@ class MonitorCommand implements CommandInterface {
 	/**
 	 * Derive codec metadata persisted for a running stream from its stream_info
 	 * JSON: player compatibility, audio/video codec names and the resolution
-	 * snapped to the nearest standard height. Extracted from the label562 block.
+	 * snapped to the nearest standard height.
 	 *
 	 * @param mixed $rStreamInfoJson stream_info JSON string (or falsy).
 	 * @param mixed $rAllowHevc      player_allow_hevc setting.
@@ -538,7 +553,7 @@ class MonitorCommand implements CommandInterface {
 	/**
 	 * Clamp a probed segment's of_duration to <= 10s, persist it to the stream's
 	 * _.dur file, and raise $rSegmentTime to it when the segment is longer.
-	 * Shared by the label195 and label562 probe blocks.
+	 * Shared by the in-loop probe and the post-start probe.
 	 *
 	 * @param mixed $rProbe       FFprobeRunner::probeStream() result.
 	 * @param mixed $rStreamID    Stream id (for the _.dur path).
@@ -556,6 +571,13 @@ class MonitorCommand implements CommandInterface {
 		return array($rProbe, $rSegmentTime);
 	}
 
+	/**
+	 * Ensure only one watchdog runs for this stream by killing any monitor
+	 * already running for it: prefers the pid stored in the `_.monitor` file,
+	 * falling back to matching the `XC_VM[<id>]` process title.
+	 *
+	 * @param int $rStreamID Stream id being monitored.
+	 */
 	private function checkRunning(int $rStreamID): void {
 		clearstatcache(true);
 		$rPID = 0;

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -146,7 +146,7 @@ class MonitorCommand implements CommandInterface {
 						echo "Auto-restart\n";
 						StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
 						$D97a4f098a8d1bf8 = false;
-						goto label1186;
+						break;
 					}
 					if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
 						echo "Probe Stream\n";
@@ -154,7 +154,7 @@ class MonitorCommand implements CommandInterface {
 						if (!empty($rSegment)) {
 							if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
-								goto label1186;
+								break;
 							}
 							$rLastSegment = $rSegment;
 							$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
@@ -194,7 +194,7 @@ class MonitorCommand implements CommandInterface {
 							} elseif ($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db)) {
 								echo "FPS dropped below threshold! Break\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
-								goto label1186;
+								break;
 							}
 						}
 						unlink(STREAMS_PATH . $rStreamID . '_.progress_check');
@@ -207,11 +207,11 @@ class MonitorCommand implements CommandInterface {
 							if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
 								echo "Lost audio! Break\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
-								goto label1186;
+								break;
 							}
 							$rAudioChecked = time();
 						} else {
-							goto label1186;
+							break;
 						}
 					}
 					if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
@@ -231,7 +231,7 @@ class MonitorCommand implements CommandInterface {
 							}
 							$rCheckedTime = time();
 						} else {
-							goto label1186;
+							break;
 						}
 					}
 					if (((SettingsManager::getAll()['priority_backup'] == 1) && (1 < count($rSources)) && ($rParentID == 0) && (300 < (time() - $rBackupsChecked)))) {
@@ -250,7 +250,7 @@ class MonitorCommand implements CommandInterface {
 										$rForceSource = $rSource;
 										$rPrioritySwitch = true;
 										$D97a4f098a8d1bf8 = false;
-										goto label1186;
+										break 2;
 									}
 								}
 							}
@@ -268,7 +268,7 @@ class MonitorCommand implements CommandInterface {
 								$rForceSource = $rSources[$rForceID];
 								unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
 								$D97a4f098a8d1bf8 = false;
-								goto label1186;
+								break;
 							}
 						}
 						unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
@@ -280,7 +280,6 @@ class MonitorCommand implements CommandInterface {
 					}
 					sleep(1);
 				}
-				label1186:
 				if ($D97a4f098a8d1bf8) {
 					StreamProcess::streamLog($rStreamID, SERVER_ID, 'STREAM_FAILED', $rCurrentSource);
 					echo "Stream failed!\n";

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -357,20 +357,7 @@ class MonitorCommand implements CommandInterface {
 			}
 
 			// Defining video/Audio parameters
-			$rCompatible = 0;
-			$rAudioCodec = $rVideoCodec = $rResolution = null;
-			if ($rStreamInfo['stream_info']) {
-				$rStreamJSON = json_decode($rStreamInfo['stream_info'], true);
-				$rCompatible = is_array($rStreamJSON) ? intval(DiagnosticsService::checkCompatibility($rStreamJSON, SettingsManager::getAll()['player_allow_hevc'])) : 0;
-				if (is_array($rStreamJSON) && isset($rStreamJSON['codecs']) && is_array($rStreamJSON['codecs'])) {
-					$rAudioCodec = isset($rStreamJSON['codecs']['audio']['codec_name']) ? $rStreamJSON['codecs']['audio']['codec_name'] : null;
-					$rVideoCodec = isset($rStreamJSON['codecs']['video']['codec_name']) ? $rStreamJSON['codecs']['video']['codec_name'] : null;
-					$rResolution = isset($rStreamJSON['codecs']['video']['height']) ? $rStreamJSON['codecs']['video']['height'] : null;
-				}
-				if ($rResolution) {
-					$rResolution = StreamSorter::getNearest(array(240, 360, 480, 576, 720, 1080, 1440, 2160), $rResolution);
-				}
-			}
+			list($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution) = self::resolveStreamCodecMeta($rStreamInfo['stream_info'], SettingsManager::getAll()['player_allow_hevc']);
 
 			if (!$ea6de21e70c530a9 && $rStreamInfo['stream_info'] && $rStreamInfo['on_demand']) {
 				if ($rStreamInfo['stream_info']) {
@@ -596,6 +583,33 @@ class MonitorCommand implements CommandInterface {
 		return in_array(date('l', $rNow), $rAutoRestart['days'])
 			&& date('H', $rNow) == $rHour
 			&& date('i', $rNow) == $rMinutes;
+	}
+
+	/**
+	 * Derive codec metadata persisted for a running stream from its stream_info
+	 * JSON: player compatibility, audio/video codec names and the resolution
+	 * snapped to the nearest standard height. Extracted from the label562 block.
+	 *
+	 * @param mixed $rStreamInfoJson stream_info JSON string (or falsy).
+	 * @param mixed $rAllowHevc      player_allow_hevc setting.
+	 * @return array{0:int,1:?string,2:?string,3:mixed} [compatible, audio, video, resolution]
+	 */
+	private static function resolveStreamCodecMeta($rStreamInfoJson, $rAllowHevc): array {
+		$rCompatible = 0;
+		$rAudioCodec = $rVideoCodec = $rResolution = null;
+		if ($rStreamInfoJson) {
+			$rStreamJSON = json_decode($rStreamInfoJson, true);
+			$rCompatible = is_array($rStreamJSON) ? intval(DiagnosticsService::checkCompatibility($rStreamJSON, $rAllowHevc)) : 0;
+			if (is_array($rStreamJSON) && isset($rStreamJSON['codecs']) && is_array($rStreamJSON['codecs'])) {
+				$rAudioCodec = isset($rStreamJSON['codecs']['audio']['codec_name']) ? $rStreamJSON['codecs']['audio']['codec_name'] : null;
+				$rVideoCodec = isset($rStreamJSON['codecs']['video']['codec_name']) ? $rStreamJSON['codecs']['video']['codec_name'] : null;
+				$rResolution = isset($rStreamJSON['codecs']['video']['height']) ? $rStreamJSON['codecs']['video']['height'] : null;
+			}
+			if ($rResolution) {
+				$rResolution = StreamSorter::getNearest(array(240, 360, 480, 576, 720, 1080, 1440, 2160), $rResolution);
+			}
+		}
+		return array($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution);
 	}
 
 	private function checkRunning(int $rStreamID): void {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -166,13 +166,7 @@ class MonitorCommand implements CommandInterface {
 				}
 				$rLastSegment = $rSegment;
 				$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-				if ((10 < intval($E02429d2ee600884['of_duration']))) {
-					$E02429d2ee600884['of_duration'] = 10;
-				}
-				file_put_contents(STREAMS_PATH . $rStreamID . '_.dur', intval($E02429d2ee600884['of_duration']));
-				if (($rSegmentTime < intval($E02429d2ee600884['of_duration']))) {
-					$rSegmentTime = intval($E02429d2ee600884['of_duration']);
-				}
+				list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
 				file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
 				$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
 			}
@@ -341,13 +335,7 @@ class MonitorCommand implements CommandInterface {
 			$rStreamInfo['stream_info'] = null;
 			if (file_exists($rSegment)) {
 				$E02429d2ee600884 = FFprobeRunner::probeStream($rSegment);
-				if ((10 < intval($E02429d2ee600884['of_duration']))) {
-					$E02429d2ee600884['of_duration'] = 10;
-				}
-				file_put_contents(STREAMS_PATH . $rStreamID . '_.dur', intval($E02429d2ee600884['of_duration']));
-				if (($rSegmentTime < intval($E02429d2ee600884['of_duration']))) {
-					$rSegmentTime = intval($E02429d2ee600884['of_duration']);
-				}
+				list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
 				if ($E02429d2ee600884) {
 					$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
 					$rBitrate = StreamUtils::getStreamBitrate('live', STREAMS_PATH . $rStreamID . '_.m3u8');
@@ -610,6 +598,27 @@ class MonitorCommand implements CommandInterface {
 			}
 		}
 		return array($rCompatible, $rAudioCodec, $rVideoCodec, $rResolution);
+	}
+
+	/**
+	 * Clamp a probed segment's of_duration to <= 10s, persist it to the stream's
+	 * _.dur file, and raise $rSegmentTime to it when the segment is longer.
+	 * Shared by the label195 and label562 probe blocks.
+	 *
+	 * @param mixed $rProbe       FFprobeRunner::probeStream() result.
+	 * @param mixed $rStreamID    Stream id (for the _.dur path).
+	 * @param mixed $rSegmentTime Current segment time.
+	 * @return array{0:mixed,1:mixed} [clamped probe, updated segment time]
+	 */
+	private static function persistSegmentDuration($rProbe, $rStreamID, $rSegmentTime): array {
+		if (10 < intval($rProbe['of_duration'])) {
+			$rProbe['of_duration'] = 10;
+		}
+		file_put_contents(STREAMS_PATH . $rStreamID . '_.dur', intval($rProbe['of_duration']));
+		if ($rSegmentTime < intval($rProbe['of_duration'])) {
+			$rSegmentTime = intval($rProbe['of_duration']);
+		}
+		return array($rProbe, $rSegmentTime);
 	}
 
 	private function checkRunning(int $rStreamID): void {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -144,87 +144,146 @@ class MonitorCommand implements CommandInterface {
 		$rMD5 = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
 		$D97a4f098a8d1bf8 = ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist);
 		$b4015d24aedaf0db = null;
-		label592: //while
-		if ((ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist))) {
+		while (ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylist)) {
 			if (self::isAutoRestartDue($rAutoRestart)) {
 				echo "Auto-restart\n";
 				StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUTO_RESTART', $rCurrentSource);
 				$D97a4f098a8d1bf8 = false;
 				goto label1186;
 			}
-			goto label195;
-		}
-		goto label1186;
-		label195:
-		if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
-			echo "Probe Stream\n";
-			$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-			if (!empty($rSegment)) {
-				if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
-					StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
+			if (($rStreamProbe || (!file_exists(STREAMS_PATH . $rStreamID . '_.dur') && (300 < (time() - $rDurationChecked))))) {
+				echo "Probe Stream\n";
+				$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+				if (!empty($rSegment)) {
+					if (((300 < (time() - $rDurationChecked)) && ($rSegment == $rLastSegment))) {
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FFMPEG_ERROR', $rCurrentSource);
+						goto label1186;
+					}
+					$rLastSegment = $rSegment;
+					$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+					list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
+					file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
+					$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
+				}
+				$rStreamProbe = false;
+				$rDurationChecked = time();
+				if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
+					file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
+				}
+				if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
+					file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
+				}
+			}
+			if (($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check')) {
+				echo "Checking FPS...\n";
+				$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
+				if (0 < $d75674a646265e7b) {
+					if (!$b4015d24aedaf0db) {
+						if (SettingsManager::getAll()['fps_check_type'] == 1) {
+							$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+							if (!empty($rSegment)) {
+								$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+								if (isset($E02429d2ee600884['codecs']['video']['avg_frame_rate']) || isset($E02429d2ee600884['codecs']['video']['r_frame_rate'])) {
+									$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
+									$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
+									if (0 < $d75674a646265e7b) {
+										$b4015d24aedaf0db = $d75674a646265e7b;
+									}
+								}
+							}
+						} else {
+							$b4015d24aedaf0db = $d75674a646265e7b;
+						}
+					} elseif ($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db)) {
+						echo "FPS dropped below threshold! Break\n";
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
+						goto label1186;
+					}
+				}
+				unlink(STREAMS_PATH . $rStreamID . '_.progress_check');
+			}
+			if ((SettingsManager::getAll()['audio_restart_loss'] == 1) && (300 < (time() - $rAudioChecked))) {
+				echo "Checking audio...\n";
+				$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
+				if (!empty($rSegment)) {
+					$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
+					if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
+						echo "Lost audio! Break\n";
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
+						goto label1186;
+					}
+					$rAudioChecked = time();
+				} else {
 					goto label1186;
 				}
-				$rLastSegment = $rSegment;
-				$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-				list($E02429d2ee600884, $rSegmentTime) = self::persistSegmentDuration($E02429d2ee600884, $rStreamID, $rSegmentTime);
-				file_put_contents(STREAMS_PATH . $rStreamID . '_.stream_info', json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE));
-				$rStreamInfo['stream_info'] = json_encode($E02429d2ee600884, JSON_UNESCAPED_UNICODE);
 			}
-			$rStreamProbe = false;
-			$rDurationChecked = time();
-			if (!file_exists(STREAMS_PATH . $rStreamID . '_.pid')) {
-				file_put_contents(STREAMS_PATH . $rStreamID . '_.pid', $rPID);
+			if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
+				$Fcfb63b23cad3c6e = md5_file($rPlaylist);
+				if ($rMD5 != $Fcfb63b23cad3c6e) {
+					$rMD5 = $Fcfb63b23cad3c6e;
+					$rCheckedTime = time();
+					if (SettingsManager::getAll()['encrypt_hls']) {
+					foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
+					if (!file_exists(rtrim($rFile, '.enc'))) {
+					unlink($rFile);
+					}
+					}
+					}
+					if ((!is_array(json_decode($rStreamInfo['stream_info'], true)) || count(json_decode($rStreamInfo['stream_info'], true)) == 0)) {
+						$rStreamProbe = true;
+					}
+					$rCheckedTime = time();
+				} else {
+					goto label1186;
+				}
 			}
-			if (!file_exists(STREAMS_PATH . $rStreamID . '_.monitor')) {
-				file_put_contents(STREAMS_PATH . $rStreamID . '_.monitor', getmypid());
+			if (((SettingsManager::getAll()['priority_backup'] == 1) && (1 < count($rSources)) && ($rParentID == 0) && (300 < (time() - $rBackupsChecked)))) {
+				echo "Checking backups...\n";
+				$rBackupsChecked = time();
+				$rKey = array_search($rCurrentSource, $rSources);
+				if ((!is_numeric($rKey) || (0 < $rKey))) {
+					foreach ($rSources as $rSource) {
+						if (!(($rSource == $rCurrentSource) || ($rSource == $rForceSource))) {
+							$rStreamSource = StreamUtils::parseStreamURL($rSource);
+							$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
+							$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
+							if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+								echo "Switch priority\n";
+								StreamProcess::streamLog($rStreamID, SERVER_ID, 'PRIORITY_SWITCH', $rSource);
+								$rForceSource = $rSource;
+								$rPrioritySwitch = true;
+								$D97a4f098a8d1bf8 = false;
+								goto label1186;
+							}
+						}
+					}
+				}
 			}
+			if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
+				$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
+				$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
+				if (($rSources[$rForceID] != $rCurrentSource)) {
+					$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
+					$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
+					if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
+						echo "Force new source\n";
+						StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
+						$rForceSource = $rSources[$rForceID];
+						unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
+						$D97a4f098a8d1bf8 = false;
+						goto label1186;
+					}
+				}
+				unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
+			}
+			if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
+				echo "Start Delay\n";
+				StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
+				$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
+			}
+			sleep(1);
 		}
-		if (!(($rStreamInfo['fps_restart'] == 1) && (SettingsManager::getAll()['fps_delay'] < (time() - $rStartedTime)) && file_exists(STREAMS_PATH . $rStreamID . '_.progress_check'))) {
-			goto label298;
-		}
-		echo "Checking FPS...\n";
-		$d75674a646265e7b = floatval(json_decode(file_get_contents(STREAMS_PATH . $rStreamID . '_.progress_check'), true)['fps']) ?: 0;
-		if (!(0 < $d75674a646265e7b)) {
-			goto label1847;
-		}
-		if (!$b4015d24aedaf0db) {
-			goto label1087;
-		}
-		if (!($b4015d24aedaf0db && (($d75674a646265e7b * ($rStreamInfo['fps_threshold'] ?: 100)) < $b4015d24aedaf0db))) {
-			goto label1847;
-		}
-		echo "FPS dropped below threshold! Break\n";
-		StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
 		goto label1186;
-		label884:
-		$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-		if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
-			echo "Force new source\n";
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'FORCE_SOURCE', $rSources[$rForceID]);
-			$rForceSource = $rSources[$rForceID];
-			unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-			$D97a4f098a8d1bf8 = false;
-			goto label1186;
-		}
-		label1631:
-		unlink(SIGNALS_TMP_PATH . $rStreamID . '.force');
-		label496:
-		if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
-			$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
-			$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
-			if (($rSources[$rForceID] != $rCurrentSource)) {
-				$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
-				goto label884;
-			}
-			goto label1631;
-		}
-		if (($rDelay && ($rStreamInfo['delay_available_at'] <= time()) && !ProcessManager::isNamedProcessRunning($rDelayPID, 'XC_VMDelay', $rStreamID))) {
-			echo "Start Delay\n";
-			StreamProcess::streamLog($rStreamID, SERVER_ID, 'DELAY_START');
-			$rDelayPID = intval(shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php delay ' . intval($rStreamID) . ' ' . intval($rStreamInfo['delay_minutes']) . ' >/dev/null 2>/dev/null & echo $!'));
-		}
-		sleep(1);
-		goto label592;
 		label1:
 		if (!$rStreamInfo['parent_id']) {
 			goto label49;
@@ -441,93 +500,6 @@ class MonitorCommand implements CommandInterface {
 			goto label644;
 		}
 		goto label235;
-		label1087:
-		if (SettingsManager::getAll()['fps_check_type'] == 1) {
-			goto label1094;
-		}
-		$b4015d24aedaf0db = $d75674a646265e7b;
-		goto label1847;
-		label1094:
-		$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-		if (empty($rSegment)) {
-			goto label1847;
-		}
-		$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-		if (!(isset($E02429d2ee600884['codecs']['video']['avg_frame_rate']) || isset($E02429d2ee600884['codecs']['video']['r_frame_rate']))) {
-			goto label1847;
-		}
-		$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
-		label768:
-		$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
-		if (0 < $d75674a646265e7b) {
-			$b4015d24aedaf0db = $d75674a646265e7b;
-		}
-		goto label1847;
-
-		label1847:
-		unlink(STREAMS_PATH . $rStreamID . '_.progress_check');
-		label298:
-		if (!((SettingsManager::getAll()['audio_restart_loss'] == 1) && (300 < (time() - $rAudioChecked)))) {
-			goto label617;
-		}
-		echo "Checking audio...\n";
-		$rSegment = StreamUtils::getPlaylistSegments($rPlaylist, 10)[0];
-		if (!empty($rSegment)) {
-			$E02429d2ee600884 = FFprobeRunner::probeStream($rFolder . $rSegment);
-			if ((!isset($E02429d2ee600884['codecs']['audio']) || empty($E02429d2ee600884['codecs']['audio']))) {
-				echo "Lost audio! Break\n";
-				StreamProcess::streamLog($rStreamID, SERVER_ID, 'AUDIO_LOSS', $rCurrentSource);
-				goto label1186;
-			}
-			$rAudioChecked = time();
-			label617:
-			if ((($rSegmentTime * 6) <= time() - $rCheckedTime)) {
-				$Fcfb63b23cad3c6e = file_exists($rPlaylist) ? md5_file($rPlaylist) : false;
-				if ($rMD5 != $Fcfb63b23cad3c6e) {
-					$rMD5 = $Fcfb63b23cad3c6e;
-					$rCheckedTime = time();
-					label1851:
-					if (SettingsManager::getAll()['encrypt_hls']) {
-						foreach (glob(STREAMS_PATH . $rStreamID . '_*.ts.enc') as $rFile) {
-							if (!file_exists(rtrim($rFile, '.enc'))) {
-								unlink($rFile);
-							}
-						}
-					}
-					if ((!is_array(json_decode($rStreamInfo['stream_info'], true)) || count(json_decode($rStreamInfo['stream_info'], true)) == 0)) {
-						$rStreamProbe = true;
-					}
-					$rCheckedTime = time();
-					goto label1095;
-				}
-				goto label1186;
-			}
-			label1095:
-			if (((SettingsManager::getAll()['priority_backup'] == 1) && (1 < count($rSources)) && ($rParentID == 0) && (300 < (time() - $rBackupsChecked)))) {
-				echo "Checking backups...\n";
-				$rBackupsChecked = time();
-				$rKey = array_search($rCurrentSource, $rSources);
-				if ((!is_numeric($rKey) || (0 < $rKey))) {
-					foreach ($rSources as $rSource) {
-						if (!(($rSource == $rCurrentSource) || ($rSource == $rForceSource))) {
-							$rStreamSource = StreamUtils::parseStreamURL($rSource);
-							$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
-							$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
-							if (($E02429d2ee600884 = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
-								echo "Switch priority\n";
-								StreamProcess::streamLog($rStreamID, SERVER_ID, 'PRIORITY_SWITCH', $rSource);
-								$rForceSource = $rSource;
-								$rPrioritySwitch = true;
-								$D97a4f098a8d1bf8 = false;
-								goto label1186;
-							}
-						}
-					}
-				}
-			}
-			goto label496;
-		}
-		goto label1186;
 		label1880:
 
 		return 0;

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -509,22 +509,10 @@ class MonitorCommand implements CommandInterface {
 		$d75674a646265e7b = $E02429d2ee600884['codecs']['video']['avg_frame_rate'] ?: $E02429d2ee600884['codecs']['video']['r_frame_rate'];
 		goto label768;
 		label768:
-		if (stripos($d75674a646265e7b, '/') !== false) {
-			goto label780;
+		$d75674a646265e7b = self::parseFrameRate($d75674a646265e7b);
+		if (0 < $d75674a646265e7b) {
+			$b4015d24aedaf0db = $d75674a646265e7b;
 		}
-		$d75674a646265e7b = floatval($d75674a646265e7b);
-		goto label1052;
-		label780:
-		list($Be71401a913607c0, $Cd98e5a46a318d0a) = array_map('floatval', explode('/', $d75674a646265e7b));
-		goto label1047;
-		label1047:
-		$d75674a646265e7b = floatval($Be71401a913607c0 / $Cd98e5a46a318d0a);
-		label1052:
-		if (!(0 < $d75674a646265e7b)) {
-			goto label1057;
-		}
-		$b4015d24aedaf0db = $d75674a646265e7b;
-		label1057:
 		goto label1847;
 
 		label1847:
@@ -594,6 +582,22 @@ class MonitorCommand implements CommandInterface {
 		label1880:
 
 		return 0;
+	}
+
+	/**
+	 * Parse an ffprobe frame-rate field ("30", "30000/1001", "25/1") into fps.
+	 * Extracted from the FPS-check goto cluster (label768/780/1047/1052/1057).
+	 *
+	 * @param mixed $rRate Raw avg_frame_rate / r_frame_rate value.
+	 * @return float Frames per second; 0.0 for empty/zero/malformed input.
+	 */
+	private static function parseFrameRate($rRate): float {
+		$rRate = (string) $rRate;
+		if (strpos($rRate, '/') !== false) {
+			list($rNum, $rDen) = array_map('floatval', explode('/', $rRate));
+			return $rDen != 0.0 ? (float) ($rNum / $rDen) : 0.0;
+		}
+		return (float) $rRate;
 	}
 
 	private function checkRunning(int $rStreamID): void {

--- a/tests/Unit/MonitorCommandTest.php
+++ b/tests/Unit/MonitorCommandTest.php
@@ -61,4 +61,36 @@ final class MonitorCommandTest extends TestCase {
 		$this->assertFalse($this->call('isAutoRestartDue', ['days' => [], 'at' => '14:30'], $now), 'empty days');
 		$this->assertFalse($this->call('isAutoRestartDue', ['days' => ['Saturday']], $now), 'no time');
 	}
+
+	// ── resolveStreamCodecMeta (label562 codec block) ──────────
+
+	public function testCodecMetaEmptyOrNonArrayJson(): void {
+		$this->assertSame([0, null, null, null], $this->call('resolveStreamCodecMeta', '', false));
+		$this->assertSame([0, null, null, null], $this->call('resolveStreamCodecMeta', null, false));
+		$this->assertSame([0, null, null, null], $this->call('resolveStreamCodecMeta', '"not-an-array"', false));
+	}
+
+	public function testCodecMetaCompatibleH264Aac(): void {
+		$json = json_encode(['codecs' => [
+			'video' => ['codec_name' => 'h264', 'height' => 1080],
+			'audio' => ['codec_name' => 'aac'],
+		]]);
+		[$compat, $audio, $video, $res] = $this->call('resolveStreamCodecMeta', $json, false);
+		$this->assertSame(1, $compat);
+		$this->assertSame('aac', $audio);
+		$this->assertSame('h264', $video);
+		$this->assertSame(1080, $res);
+	}
+
+	public function testCodecMetaResolutionSnapsAndHevcGated(): void {
+		$json = json_encode(['codecs' => [
+			'video' => ['codec_name' => 'h264', 'height' => 700],
+			'audio' => ['codec_name' => 'aac'],
+		]]);
+		$this->assertSame(720, $this->call('resolveStreamCodecMeta', $json, false)[3], '700 -> nearest 720');
+
+		$hevc = json_encode(['codecs' => ['video' => ['codec_name' => 'hevc', 'height' => 2160], 'audio' => ['codec_name' => 'ac3']]]);
+		$this->assertSame(0, $this->call('resolveStreamCodecMeta', $hevc, false)[0], 'hevc not allowed');
+		$this->assertSame(1, $this->call('resolveStreamCodecMeta', $hevc, true)[0], 'hevc allowed');
+	}
 }

--- a/tests/Unit/MonitorCommandTest.php
+++ b/tests/Unit/MonitorCommandTest.php
@@ -35,4 +35,30 @@ final class MonitorCommandTest extends TestCase {
 		$this->assertSame(0.0, $this->call('parseFrameRate', '0/0'), 'division-by-zero guarded');
 		$this->assertSame(0.0, $this->call('parseFrameRate', '30/0'), 'zero denominator guarded');
 	}
+
+	// ── isAutoRestartDue (label195 schedule chain) ─────────────
+
+	public function testAutoRestartDueWhenDayHourMinuteMatch(): void {
+		$now = mktime(14, 30, 0, 8, 8, 2026);
+		// derive the expected components from the same $now -> timezone-agnostic.
+		$day = date('l', $now);
+		$at  = date('H', $now) . ':' . date('i', $now);
+		$this->assertTrue($this->call('isAutoRestartDue', ['days' => [$day], 'at' => $at], $now));
+	}
+
+	public function testAutoRestartNotDueOnMismatch(): void {
+		$now = mktime(14, 30, 0, 8, 8, 2026);
+		$day = date('l', $now);
+		$at  = date('H', $now) . ':' . date('i', $now);
+		$this->assertFalse($this->call('isAutoRestartDue', ['days' => ['Nonesuch'], 'at' => $at], $now), 'wrong day');
+		$this->assertFalse($this->call('isAutoRestartDue', ['days' => [$day], 'at' => ((intval(date('H', $now)) + 1) % 24) . ':' . date('i', $now)], $now), 'wrong hour');
+		$this->assertFalse($this->call('isAutoRestartDue', ['days' => [$day], 'at' => date('H', $now) . ':' . (((intval(date('i', $now)) + 1) % 60)) ], $now), 'wrong minute');
+	}
+
+	public function testAutoRestartNotDueWhenUnconfigured(): void {
+		$now = mktime(14, 30, 0, 8, 8, 2026);
+		$this->assertFalse($this->call('isAutoRestartDue', [], $now));
+		$this->assertFalse($this->call('isAutoRestartDue', ['days' => [], 'at' => '14:30'], $now), 'empty days');
+		$this->assertFalse($this->call('isAutoRestartDue', ['days' => ['Saturday']], $now), 'no time');
+	}
 }

--- a/tests/Unit/MonitorCommandTest.php
+++ b/tests/Unit/MonitorCommandTest.php
@@ -10,6 +10,15 @@ use XcVm\Cli\Commands\MonitorCommand;
  */
 final class MonitorCommandTest extends TestCase {
 
+	public static function setUpBeforeClass(): void {
+		if (!defined('STREAMS_PATH')) {
+			define('STREAMS_PATH', sys_get_temp_dir() . '/xcvm-mon-test/');
+		}
+		if (!is_dir(STREAMS_PATH)) {
+			mkdir(STREAMS_PATH, 0777, true);
+		}
+	}
+
 	/** Invoke a private static MonitorCommand method via reflection. */
 	private function call(string $method, ...$args) {
 		$m = new ReflectionMethod(MonitorCommand::class, $method);
@@ -92,5 +101,23 @@ final class MonitorCommandTest extends TestCase {
 		$hevc = json_encode(['codecs' => ['video' => ['codec_name' => 'hevc', 'height' => 2160], 'audio' => ['codec_name' => 'ac3']]]);
 		$this->assertSame(0, $this->call('resolveStreamCodecMeta', $hevc, false)[0], 'hevc not allowed');
 		$this->assertSame(1, $this->call('resolveStreamCodecMeta', $hevc, true)[0], 'hevc allowed');
+	}
+
+	// ── persistSegmentDuration (label195/label562 probe core) ──
+
+	public function testPersistSegmentDurationClampsAndBumps(): void {
+		[$probe, $seg] = $this->call('persistSegmentDuration', ['of_duration' => 15], 4242, 4);
+		$this->assertSame(10, $probe['of_duration'], 'clamped to 10');
+		$this->assertSame(10, $seg, 'segTime bumped to clamped duration');
+		$this->assertSame('10', file_get_contents(STREAMS_PATH . '4242_.dur'));
+	}
+
+	public function testPersistSegmentDurationShortSegmentBumpsOrKeeps(): void {
+		[$probe, $seg] = $this->call('persistSegmentDuration', ['of_duration' => 6], 4243, 4);
+		$this->assertSame(6, $probe['of_duration'], 'not clamped');
+		$this->assertSame(6, $seg, 'segTime bumped 4 -> 6');
+
+		[, $seg2] = $this->call('persistSegmentDuration', ['of_duration' => 6], 4243, 8);
+		$this->assertSame(8, $seg2, 'segTime kept (already larger)');
 	}
 }

--- a/tests/Unit/MonitorCommandTest.php
+++ b/tests/Unit/MonitorCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use XcVm\Cli\Commands\MonitorCommand;
+
+/**
+ * Unit tests for pure helpers extracted from MonitorCommand's obfuscated
+ * goto-based execute(). Each helper replaces a self-contained goto cluster; the
+ * tests lock its behaviour so the control-flow untangling cannot silently drift.
+ */
+final class MonitorCommandTest extends TestCase {
+
+	/** Invoke a private static MonitorCommand method via reflection. */
+	private function call(string $method, ...$args) {
+		$m = new ReflectionMethod(MonitorCommand::class, $method);
+		$m->setAccessible(true);
+		return $m->invoke(null, ...$args);
+	}
+
+	// ── parseFrameRate (label768/780/1047/1052/1057) ───────────
+
+	public function testPlainInteger(): void {
+		$this->assertSame(30.0, $this->call('parseFrameRate', '30'));
+		$this->assertSame(25.0, $this->call('parseFrameRate', 25));
+	}
+
+	public function testRationalFrameRate(): void {
+		$this->assertSame(25.0, $this->call('parseFrameRate', '25/1'));
+		$this->assertEqualsWithDelta(29.97, $this->call('parseFrameRate', '30000/1001'), 0.001);
+	}
+
+	public function testZeroAndMalformedAreZero(): void {
+		$this->assertSame(0.0, $this->call('parseFrameRate', ''));
+		$this->assertSame(0.0, $this->call('parseFrameRate', '0'));
+		$this->assertSame(0.0, $this->call('parseFrameRate', '0/0'), 'division-by-zero guarded');
+		$this->assertSame(0.0, $this->call('parseFrameRate', '30/0'), 'zero denominator guarded');
+	}
+}


### PR DESCRIPTION
## Summary

Untangle **`MonitorCommand`** — the per-stream watchdog the whole streaming pipeline hangs on — from obfuscation residue: a `goto`/label state machine (62 gotos, 14 numeric labels) with hash-named variables. Done incrementally, one reviewable commit per step, with behaviour verified by a **live canary** at every structural step.

Result: **goto 62 → 0, labels 14 → 0**, hash-named variables renamed, four self-contained blocks extracted into unit-tested helpers, class docs rewritten in English. **No behaviour change** — start/restart/monitor traces are byte-identical to the pre-refactor original (validated live against stream 567).

**What changed**

- **Control flow** → structured `while`: wait-for-playlist loop, inner health-monitoring loop, and the supervisor (`while (true)` + start dispatch as `if/elseif/else` with a nested retry loop; probe result as `if/else`); the last 8 in-loop exits → `break` / `break 2`.
- **Extractions (tested):** `parseFrameRate`, `isAutoRestartDue`, `resolveStreamCodecMeta`, `persistSegmentDuration`.
- **Variables:** 10 hash-named locals renamed by role (`$E02429d2ee600884`→`$rProbe`, `$D97a4f098a8d1bf8`→`$rStreamFailed`, …).
- **Docs:** English class docblock; docblocks added to `getName`/`getDescription`/`execute`/`checkRunning`.

**Bug caught pre-merge:** the supervisor reorder first turned the probe success branch's `goto label554` into a fall-through, skipping the failure branch — a healthy start would fall into "Stream start failed" and restart-loop. The live canary caught it; fixed (failure branch is now the `else`) before the commit landed.

**Verification:** every commit — `php -l`, PHPStan L5, PHPUnit (11 tests), `make gates`, php-cs-fixer; structural commits additionally canary-validated (OLD vs NEW trace byte-identical). Adds one `phpstan-baseline.neon` entry (`parseFrameRate() is unused`) that is now stale post-refactor but harmless (`reportUnmatchedIgnoredErrors: false`) — droppable on the next baseline regen.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [x] Documentation
- [ ] Build / CI / tooling

## Checklist

- [x] Code follows the project conventions (see `.github/instructions/php-conventions.instructions.md`).
- [x] Added/updated tests for the change where applicable.
- [x] Documentation updated where applicable (`docs/`, README).

## Summary by Sourcery

Refactor the per-stream MonitorCommand supervisor into structured loops with helper methods while preserving monitoring behaviour and improving documentation and testability.

Enhancements:
- Replace the obfuscated goto/label state machine in MonitorCommand with a readable supervisor and health-monitoring loop using structured control flow.
- Introduce focused helper methods for frame-rate parsing, auto-restart scheduling, codec metadata derivation, and segment duration persistence to simplify execute().
- Rename opaque, hash-like local variables in MonitorCommand to meaningful names to clarify their roles.
- Add detailed English docblocks for MonitorCommand, its lifecycle methods, and internal helpers to explain the monitoring responsibilities.

Documentation:
- Update MonitorCommand class-level documentation to describe the CLI usage and its role as a per-stream watchdog in clear English.

Tests:
- Add a unit test suite for the new MonitorCommand helper methods to lock in behaviour for frame-rate parsing, auto-restart scheduling, codec metadata resolution, and segment duration persistence.