### PR TITLE
docs(readme): fix doc links for the MkDocs URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ It enables:
 ## 📚 Documentation
 
 * 🇬🇧 **English Guide**
-  [https://vateron-media.github.io/XC_VM/#/en-us/](https://vateron-media.github.io/XC_VM/#/en-us/)
+  [https://vateron-media.github.io/XC_VM/](https://vateron-media.github.io/XC_VM/)
 
 * 🇷🇺 **Руководство на русском**
-  [https://vateron-media.github.io/XC_VM/#/ru-ru/](https://vateron-media.github.io/XC_VM/#/ru-ru/)
+  [https://vateron-media.github.io/XC_VM/ru/](https://vateron-media.github.io/XC_VM/ru/)
 
 ---
 
@@ -77,7 +77,7 @@ It enables:
 Migrating from Xtream Codes / XUI.one? Follow the step-by-step migration guide:
 
 * 📖 **Migration Guide**
-  [https://vateron-media.github.io/XC_VM/#/en-us/info/migration_guide](https://vateron-media.github.io/XC_VM/#/en-us/info/migration_guide)
+  [https://vateron-media.github.io/XC_VM/info/migration_guide/](https://vateron-media.github.io/XC_VM/info/migration_guide/)
 
 ---
 


### PR DESCRIPTION
The root README still linked to the old Docsify hash routes, which 404 after the MkDocs Material migration (#159). Updated the three links:

- English guide: `…/XC_VM/#/en-us/` → `…/XC_VM/`
- Russian guide: `…/XC_VM/#/ru-ru/` → `…/XC_VM/ru/`
- Migration guide: `…/XC_VM/#/en-us/info/migration_guide` → `…/XC_VM/info/migration_guide/`

Repo-wide grep confirms no other stale Docsify links remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix README documentation links for the MkDocs URL structure.

Bug Fixes:
- Update the README documentation links to use the current MkDocs URL scheme and prevent broken links after the Docsify-to-MkDocs migration.

Documentation:
- Correct the English guide, Russian guide, and migration guide URLs in the root README.