### PR TITLE
feat(bin): auto-update yt-dlp daily (reuse the binaries self-heal cron)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Migrating from Xtream Codes / XUI.one? Follow the step-by-step migration guide:
 | FFmpeg    | 8.0, 7.1, 4.0                        | Media transcoding & processing  |
 | MariaDB   | 11.4      | SQL database engine             |
 | KeyDB     | 6.3.4      | Cache & session storage (Redis) |
-| yt-dlp    | 2025.07.21 | Audio/Video downloader          |
 
 ---
 

--- a/src/Cli/Commands/YtDlpCommand.php
+++ b/src/Cli/Commands/YtDlpCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace XcVm\Cli\Commands;
+
+use XcVm\Cli\CommandInterface;
+use XcVm\Core\Updates\GitHubReleases;
+
+/**
+ * YtDlpCommand — install/update the bundled yt-dlp binary from upstream releases.
+ *
+ * yt-dlp resolves direct media URLs ({@see \XcVm\Core\Util\StreamUtils}); as a
+ * static bundled binary it goes stale between panel releases and breaks
+ * extraction. This is the panel-side updater, modelled on {@see FanoutBinaryCommand}:
+ * it reads the installed version from the binary (`yt-dlp --version`), compares it
+ * to the latest upstream release, and on a mismatch downloads the release asset,
+ * verifies its SHA-256, run-tests it and installs it atomically.
+ *
+ * Source is upstream `yt-dlp/yt-dlp` (the python-zip `yt-dlp` asset — architecture
+ * independent, needs a system python3). Polled ~daily by `cron:root_signals`
+ * (stamp `ytdlp_check`), so no dedicated cron/crontab row is required.
+ *
+ * Usage: `console.php ytdlp` (add `force` to reinstall the same version).
+ *
+ * @package XC_VM_CLI_Commands
+ * @author  Divarion_D <https://github.com/Divarion-D>
+ * @copyright 2025-2026 Vateron Media
+ * @link    https://github.com/Vateron-Media/XC_VM
+ * @license AGPL-3.0 https://www.gnu.org/licenses/agpl-3.0.html
+ */
+class YtDlpCommand implements CommandInterface {
+	private const REPO_OWNER = 'yt-dlp';
+	private const REPO_NAME  = 'yt-dlp';
+	private const ASSET      = 'yt-dlp'; // python-zip variant (arch independent)
+
+	public function getName(): string {
+		return 'ytdlp';
+	}
+
+	public function getDescription(): string {
+		return 'Install/update the yt-dlp binary from its upstream release';
+	}
+
+	public function execute(array $rArgs): int {
+		if (posix_getpwuid(posix_geteuid())['name'] !== 'root') {
+			echo "Please run as root!\n";
+			return 1;
+		}
+		$rForce = in_array('force', $rArgs, true);
+
+		$rBinary = YOUTUBE_BIN;
+		$rDir = dirname($rBinary);
+		if (!is_dir($rDir)) {
+			echo "yt-dlp target dir {$rDir} missing — skipping\n";
+			return 0;
+		}
+		$rInstalled = $this->installedVersion($rBinary);
+
+		try {
+			$rGit = new GitHubReleases(self::REPO_OWNER, self::REPO_NAME, 'stable');
+			$rGit->setTimeout(20);
+			$rReleases = $rGit->getReleases();
+		} catch (\Exception $e) {
+			echo 'Failed to check yt-dlp releases: ' . $e->getMessage() . "\n";
+			return 1;
+		}
+		if (empty($rReleases[0])) {
+			echo "Failed to resolve the latest yt-dlp release.\n";
+			return 1;
+		}
+		$rTag = trim($rReleases[0]);
+		$rLatest = ltrim($rTag, 'vV');
+
+		if (!$rForce && $rInstalled !== null && $rInstalled === $rLatest) {
+			echo "yt-dlp is up to date ({$rInstalled}).\n";
+			return 0;
+		}
+		echo 'yt-dlp: installed=' . ($rInstalled ?? 'none') . ', latest=' . $rLatest . " → updating\n";
+
+		$rBase = 'https://github.com/' . self::REPO_OWNER . '/' . self::REPO_NAME
+			. '/releases/download/' . rawurlencode($rTag) . '/';
+		$rTmp = $rDir . '/.yt-dlp.new';
+
+		if (!$this->download($rBase . self::ASSET, $rTmp)) {
+			echo 'Failed to download ' . self::ASSET . "\n";
+			@unlink($rTmp);
+			return 1;
+		}
+
+		// Upstream publishes checksums as SHA2-256SUMS (not SHA256SUMS).
+		$rExpected = $this->expectedSha256($rBase . 'SHA2-256SUMS', self::ASSET);
+		if ($rExpected === null) {
+			echo "Failed to fetch SHA2-256SUMS\n";
+			@unlink($rTmp);
+			return 1;
+		}
+		if (!hash_equals($rExpected, hash_file('sha256', $rTmp))) {
+			echo 'Checksum mismatch for ' . self::ASSET . " — aborting\n";
+			@unlink($rTmp);
+			return 1;
+		}
+
+		@chmod($rTmp, 0755);
+		// Run-test: proves the fresh binary actually runs with the host python3
+		// before we swap it in — a broken download must never replace a working one.
+		$rNewVer = trim((string) shell_exec(escapeshellarg($rTmp) . ' --version 2>/dev/null'));
+		if ($rNewVer === '') {
+			echo "Downloaded binary does not run on this host — aborting\n";
+			@unlink($rTmp);
+			return 1;
+		}
+
+		if (!@rename($rTmp, $rBinary)) { // atomic replace
+			echo "Failed to install {$rBinary}\n";
+			@unlink($rTmp);
+			return 1;
+		}
+		@chown($rBinary, 'xc_vm');
+		@chgrp($rBinary, 'xc_vm');
+		@chmod($rBinary, 0755);
+
+		echo "yt-dlp {$rNewVer} installed.\n";
+		return 0;
+	}
+
+	/** Installed version straight from the binary, or null if absent/unrunnable. */
+	private function installedVersion(string $rBinary): ?string {
+		if (!is_file($rBinary) || !is_executable($rBinary)) {
+			return null;
+		}
+		$rOut = trim((string) shell_exec(escapeshellarg($rBinary) . ' --version 2>/dev/null'));
+		return $rOut !== '' ? ltrim($rOut, 'vV') : null;
+	}
+
+	/** Download a URL to a file (following redirects). */
+	private function download(string $rUrl, string $rDest): bool {
+		$rFp = @fopen($rDest, 'wb');
+		if (!$rFp) {
+			return false;
+		}
+		$rCurl = curl_init();
+		curl_setopt_array($rCurl, [
+			CURLOPT_URL            => $rUrl,
+			CURLOPT_FILE           => $rFp,
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_CONNECTTIMEOUT => 20,
+			CURLOPT_TIMEOUT        => 120,
+			CURLOPT_FAILONERROR    => true,
+			CURLOPT_USERAGENT      => 'XC_VM',
+		]);
+		$rOk = curl_exec($rCurl);
+		$rCode = curl_getinfo($rCurl, CURLINFO_HTTP_CODE);
+		curl_close($rCurl);
+		fclose($rFp);
+
+		return $rOk !== false && $rCode >= 200 && $rCode < 300 && filesize($rDest) > 0;
+	}
+
+	/** Expected sha256 for $rAsset from a SHA256SUMS-style file (`<hash>  <name>`). */
+	private function expectedSha256(string $rUrl, string $rAsset): ?string {
+		$rCurl = curl_init();
+		curl_setopt_array($rCurl, [
+			CURLOPT_URL            => $rUrl,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_CONNECTTIMEOUT => 15,
+			CURLOPT_TIMEOUT        => 30,
+			CURLOPT_USERAGENT      => 'XC_VM',
+		]);
+		$rBody = curl_exec($rCurl);
+		$rCode = curl_getinfo($rCurl, CURLINFO_HTTP_CODE);
+		curl_close($rCurl);
+		if (!is_string($rBody) || $rCode < 200 || $rCode >= 300) {
+			return null;
+		}
+
+		foreach (explode("\n", $rBody) as $rLine) {
+			$rParts = preg_split('/\s+/', trim($rLine), 2);
+			if (count($rParts) === 2 && ltrim(trim($rParts[1]), '*./') === $rAsset) {
+				return strtolower(trim($rParts[0]));
+			}
+		}
+		return null;
+	}
+}

--- a/src/Cli/CronJobs/RootSignalsCronJob.php
+++ b/src/Cli/CronJobs/RootSignalsCronJob.php
@@ -337,6 +337,20 @@ class RootSignalsCronJob implements CommandInterface {
             shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php xcvm_core >/dev/null 2>&1 &');
         }
 
+        // yt-dlp — same self-heal rationale. It is a static bundled binary that
+        // resolves media URLs (StreamUtils) and nothing else keeps it current, so
+        // it goes stale between panel releases and breaks extraction. The `ytdlp`
+        // command is idempotent (version-compared against the upstream release,
+        // downloads only on a mismatch, SHA-verified + run-tested before an atomic
+        // swap), so it is safe to poll. Daily is enough (yt-dlp releases ~weekly);
+        // the first pass (stamp absent) runs immediately. Runs on every node that
+        // has the binary (main + LB).
+        $rYtDlpStamp = CRONS_TMP_PATH . 'ytdlp_check';
+        if (!file_exists($rYtDlpStamp) || time() - intval(@file_get_contents($rYtDlpStamp) ?: 0) > 86400) {
+            file_put_contents($rYtDlpStamp, time());
+            shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php ytdlp >/dev/null 2>&1 &');
+        }
+
         if ($rServers[SERVER_ID]['limit_requests'] > 0) {
             $rLimitConf = 'limit_req_zone global zone=two:10m rate=' . intval($rServers[SERVER_ID]['limit_requests']) . 'r/s;';
         } else {

--- a/src/Public/Views/admin/settings.php
+++ b/src/Public/Views/admin/settings.php
@@ -53,6 +53,11 @@ if (!isset($__settingsViewMode)):
 		? (trim((string) file_get_contents($rCoreVerFile)) ?: 'N/A')
 		: (extension_loaded('xcvm_core') ? (phpversion('xcvm_core') ?: 'N/A') : 'N/A');
 
+	// yt-dlp (`--version`) — auto-updated daily by cron:root_signals (`console.php ytdlp`).
+	$YtDlpVersion = (is_file(YOUTUBE_BIN) && is_executable(YOUTUBE_BIN))
+		? (trim((string) shell_exec(escapeshellarg(YOUTUBE_BIN) . ' --version 2>/dev/null')) ?: 'N/A')
+		: 'N/A';
+
 	$_TITLE = "Settings";
 
 	require_once __DIR__ . '/../layouts/admin.php';
@@ -2721,6 +2726,16 @@ $isAjaxRequest = (
 															<td class="text-center">
 																<button type="button" class="btn btn-dark btn-sm" style="font-size: 0.85rem;"><?= $XcvmCoreVersion ?></button>
 															</td>
+														</tr>
+
+														<tr>
+															<td class="text-center" style="font-size: 0.85rem;">yt-dlp</td>
+															<td class="text-center">
+																<button type="button" class="btn btn-info btn-sm" style="font-size: 0.85rem;"><?= $YtDlpVersion ?></button>
+															</td>
+
+															<td class="text-center" style="font-size: 0.85rem;"></td>
+															<td class="text-center"></td>
 														</tr>
 													</tbody>
 												</table>


### PR DESCRIPTION
## Why

`yt-dlp` resolves media URLs (`StreamUtils` → `--get-url --skip-download`) but is a **static bundled binary** that only refreshes when the whole panel updates. The shipped `2025.07.21` is ~13 months stale, which breaks extraction. This makes the server keep yt-dlp current on its own.

## What

Reuses the **existing binaries self-heal mechanism** — no new cron, no `crontab` row, no migration:

- **`console.php ytdlp`** (`src/Cli/Commands/YtDlpCommand.php`), modelled on `FanoutBinaryCommand`: resolves the latest upstream `yt-dlp/yt-dlp` release, and on a version mismatch downloads the `yt-dlp` asset, verifies it against upstream **`SHA2-256SUMS`**, run-tests `--version`, then **atomically** swaps it in and chowns `xc_vm`. A broken download never replaces a working binary. Root-only (installs into `bin/`).
- **`RootSignalsCronJob`**: polls `console.php ytdlp` **daily** (stamp `ytdlp_check`, 86400s), right next to the `fanout_binary` / `xcvm_core` self-heal — runs on **main + LB**, first pass immediately.
- **Settings → Info**: shows the live yt-dlp `--version` badge.
- **README**: drops the (now auto-updated, always-stale) yt-dlp version row.

## Validation

Verified the upstream contract end-to-end: latest tag `2026.08.19`, `SHA2-256SUMS` contains a `yt-dlp` entry, downloaded asset checksum **matches**, and the `--version` run-test returns `2026.08.19`. `php -l` clean on all files.

## Note

A panel update re-ships the committed `bin/yt-dlp` (repo baseline), briefly downgrading; the daily cron re-upgrades within 24h. Optional future refinement: clear the `ytdlp_check` stamp in the update flow to re-upgrade immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Automatically maintain the bundled yt-dlp binary through the existing daily self-heal process and expose its live version in the admin interface.

New Features:
- Add a root-only command that automatically updates the bundled yt-dlp binary from upstream releases.
- Display the installed yt-dlp version in the admin Settings → Info page.

Bug Fixes:
- Keep yt-dlp current between panel releases to reduce media URL extraction failures caused by stale binaries.

Enhancements:
- Reuse the root self-heal cron to check for yt-dlp updates daily across applicable nodes.
- Protect binary updates with checksum verification, execution validation, and atomic replacement.

Documentation:
- Remove the fixed yt-dlp version from the README component table.