### PR TITLE
fix(vod): stop cron:vod aborting on degenerate ffprobe output (PHP 8)

### DIFF
--- a/src/Cli/CronJobs/VodCronJob.php
+++ b/src/Cli/CronJobs/VodCronJob.php
@@ -110,11 +110,40 @@ class VodCronJob implements CommandInterface {
                     } else {
                         $rMoviePath = VOD_PATH . intval($rRow['stream_id']) . '.' . escapeshellcmd($rRow['target_container']);
                         if ($rFFProbee = FFprobeRunner::probeStream($rMoviePath)) {
+                            if (!isset($rFFProbee['codecs']['video']) || !is_array($rFFProbee['codecs']['video'])) {
+                                // ffprobe opened the file but found no usable video stream
+                                // (e.g. a truncated/placeholder upload): parseFFProbe returns
+                                // '' for the missing codec, and the VALID branch below treats
+                                // it as an array ($rFFProbee['codecs']['video']['codec_name']),
+                                // which is a TypeError on PHP 8 that aborts the whole analyzer
+                                // run and leaves every remaining movie stuck in `to_analyze = 1`
+                                // (yellow) forever. Treat such a file as broken instead.
+                                $db->query('UPDATE `streams_servers` SET `to_analyze` = 0,`stream_status` = 1 WHERE `server_stream_id` = ?', $rRow['server_stream_id']);
+                                echo 'BROKEN (no video stream)' . "\n";
+                                StreamProcess::updateStream($rRow['stream_id']);
+                                continue;
+                            }
+                            // ffprobe (especially over network/rclone mounts) can still
+                            // return a partial result for an odd file — e.g. a video stream
+                            // but no audio, where parseFFProbe stores '' (a string) instead
+                            // of an array. The VALID branch dereferences these as arrays
+                            // ($rFFProbee['codecs']['audio']['codec_name']), a TypeError on
+                            // PHP 8 that aborts the whole run. Normalise to arrays.
+                            foreach (array('video', 'audio') as $rCodecKind) {
+                                if (!is_array($rFFProbee['codecs'][$rCodecKind] ?? null)) {
+                                    $rFFProbee['codecs'][$rCodecKind] = array();
+                                }
+                            }
                             $rDuration = (isset($rFFProbee['duration']) ? $rFFProbee['duration'] : 0);
                             sscanf($rDuration, '%d:%d:%d', $rHours, $rMinutes, $rSeconds);
                             $rSeconds = (isset($rSeconds) ? $rHours * 3600 + $rMinutes * 60 + $rSeconds : $rHours * 60 + $rMinutes);
                             $rSize = filesize($rMoviePath);
-                            $rBitrate = round(($rSize * 0.008) / $rSeconds);
+                            // Guard against a zero/unknown duration (ffprobe reports
+                            // 'N/A' for truncated or duration-less files): dividing by
+                            // it throws DivisionByZeroError on PHP 8, which aborts the
+                            // whole analyzer run and leaves every remaining movie stuck
+                            // in `to_analyze = 1` (yellow) forever.
+                            $rBitrate = ($rSeconds > 0 ? round(($rSize * 0.008) / $rSeconds) : 0);
                             $rMovieProperties = json_decode($rRow['movie_properties'], true);
                             if (!is_array($rMovieProperties)) {
                                 $rMovieProperties = array();


### PR DESCRIPTION
The VOD analyzer processes to_analyze rows in a single pass and dies on the first bad file, so on PHP 8 a single unplayable/placeholder movie leaves every remaining episode stuck at `to_analyze = 1` (yellow) forever — the queue is empty yet thousands of episodes never turn green/red.

Two PHP 7 -> 8 regressions in the VALID branch, both hit by files ffprobe can open but returns degenerate metadata for (e.g. a truncated upload or an image mislabelled as .mp4):

- `round(($rSize * 0.008) / $rSeconds)` threw DivisionByZeroError when the duration is 'N/A' (parsed seconds = 0).
- `$rFFProbee['codecs']['audio'|'video']['codec_name']` threw "Cannot access offset of type string on string": parseFFProbe() stores '' for a missing codec, which the branch dereferences as an array.

Fix: guard the bitrate division; treat a probe with no video stream as BROKEN and skip it; normalise codecs.video/codecs.audio to arrays before use. The analyzer now advances past bad rows instead of aborting the whole run.

<!--
  Thanks for contributing to XC_VM!
  Please fill in the sections below and complete the checklist.
-->

## Summary

<!-- What does this PR do and why? Link related issues, e.g. "Closes #123". -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [ ] Code follows the project conventions (see `.github/instructions/php-conventions.instructions.md`).
- [ ] Added/updated tests for the change where applicable.
- [ ] Documentation updated where applicable (`docs/`, README).

## Summary by Sourcery

Keep VOD analysis progressing when ffprobe returns degenerate metadata under PHP 8.

Bug Fixes:
- Prevent VOD analysis from aborting on files with missing video streams, incomplete codec metadata, or unknown durations, allowing subsequent queued items to be processed.

Enhancements:
- Classify files without usable video streams as broken and safely handle partial ffprobe codec results.