### PR TITLE
fix(streaming): daemon-only delivery gaps — delay, kicks, encrypted HLS, catch-up, LLOD

### DIFF
--- a/docs/en/development/streaming-subsystem.md
+++ b/docs/en/development/streaming-subsystem.md
@@ -189,11 +189,11 @@ Main delivery endpoint (~650 lines):
 
 ### VOD (vod.php)
 
-Same auth flow as live. Reads from `VOD_PATH` instead of `STREAMS_PATH`.
+Same auth flow as live. Reads from `VOD_PATH` instead of `STREAMS_PATH`. Byte ranges (seeking) are resolved by `Streaming\Delivery\HttpRange` (RFC 7233 single ranges, suffix ranges included). A direct-proxy movie is relayed with cURL, asking the source for exactly the requested range.
 
 ### Timeshift (timeshift.php)
 
-Serves archived segments (timeshift / catch-up) from the archive path.
+Serves archived segments (timeshift / catch-up) from the archive path. A TS request streams the minute files back to back; a byte range (a seek) is mapped onto them — files before the start are skipped, the first is entered at the right offset and delivery stops at the range end.
 
 ### Daemon delivery — `xc_fanout`
 
@@ -204,18 +204,36 @@ PHP-FPM worker for the life of the stream.
 - **Fan-out.** `xc_fanout` (a bundled Go daemon) pulls each source **once** and
   fans it out to every viewer over a unix socket, with an in-RAM HLS segmenter.
   PHP is out of the per-viewer byte path: the worker-per-viewer chase-read
-  serving loop and the `HLSGenerator::generateHLS()` client-serving path are no
-  longer used for live delivery (`generateHLS()` is retained in the class but has
-  no callers). `AsyncFileOperations::awaitFileExists()` is **not** removed — it is
-  still used for stream-startup waits and the VOD/timeshift byte path (see the
-  Performance table).
+  serving loop and the on-disk `generateHLS()` client path are gone.
+  `AsyncFileOperations::awaitFileExists()` is still used for stream-startup
+  waits and the VOD/timeshift byte path (see the Performance table).
+- **Who feeds the daemon.** Since the daemon is the only client path, every live
+  producer must feed it, or the channel cannot be watched:
+  the stream's ffmpeg tees into its ingest socket (`buildLive()`; loopback
+  children included), the daemon supervisor's producers do the same, the PHP
+  producers — the LLOD segmenter (`LlodCommand`) and the loopback relay
+  (`LoopbackCommand`) — push through `Streaming\Fanout\IngestFeeder`, and a
+  **delayed** stream is fed by `DelayCommand`, which pushes each delayed segment
+  as it publishes it, paced over the segment's duration (its encoder output is
+  the undelayed one, so the tee is not used for it). `IngestFeeder` buffers what
+  a non-blocking write could not send (a short write no longer tears packets),
+  re-registers and redials after a daemon restart, and carries the HLS key.
 - **Two sockets.** A client socket (nginx-facing) serves `/live/<id>` and
   `/hls/...`; a PHP-only control socket registers sources
   (`PUT /streams/<id>` / `/ingest/<id>`), answers off-air status
   (`GET /streams/<id>`, `GET /probe/<id>`) and exposes telemetry.
 - **Telemetry / reconciliation.** `fanout_sync` polls `GET /rates` (per-uuid
-  KB/s → `lines_divergence`) and `GET /connections` (reconciles `lines_live`
-  rows, since PHP cannot see a disconnect under `X-Accel`).
+  KB/s → `lines_divergence`) and reconciles `GET /connections` against the
+  `lines_live` rows in both directions: a row whose viewer left the daemon is
+  closed (PHP cannot see a disconnect under `X-Accel`), and a daemon viewer whose
+  row is gone — reaped, expired or banned line — is dropped after a 20 s grace
+  (`DELETE /connections/<uuid>`).
+- **Kicks and connection limits.** A daemon-served TS viewer's row has `pid = 0`:
+  there is no worker to kill. `ConnectionLimiter` / `ConnectionTracker::closeConnection()`
+  end it with `ConnectionTracker::dropDaemonViewer()` — `FanoutClient::dropConnection()`
+  on this node, or a `drop_con` signal that the viewer's node turns into the
+  same call. The limiter never evicts the requesting connection itself (it is
+  identified by uuid, since every daemon row shares pid 0).
 - **Off-air.** If the daemon reports no data (`has_data=false` / stale), PHP
   shows a "not on air" page instead of letting the viewer hang.
 - **On-disk HLS retained** only for timeshift / thumbnails / `.analyse` /
@@ -401,7 +419,11 @@ File-based IP blocking. Block files are created by upstream flood detection logi
 
 ### 3. ConnectionLimiter (per-user)
 
-Enforced after token validation. Limits concurrent streams per user based on `max_connections`.
+Enforced after token validation. Limits concurrent streams per user based on `max_connections`, closing the oldest connections first (the requesting device's own older ones before others). Daemon-served viewers are disconnected through the daemon — see [Daemon delivery](#daemon-delivery-xc_fanout).
+
+### 4. Proxy-only servers
+
+A server with `enable_proxy` only accepts requests that arrive through one of its proxies. `auth.php` checks the TCP peer nginx saw — `XC_PEER_ADDR`, set to `$realip_remote_addr` in the stream location of `nginx.conf` — not a request header, which the client controls.
 
 ---
 
@@ -409,12 +431,12 @@ Enforced after token validation. Limits concurrent streams per user based on `ma
 
 Client HLS is served by the `xc_fanout` daemon (see [Daemon delivery](#daemon-delivery-xc_fanout)), so encryption happens **daemon-side**:
 
-1. `StreamProcess` writes the stream's AES-128 key/IV to `content/streams/<id>_.key` / `_.iv`.
-2. At ingest registration (`FanoutClient::registerIngest`), when `encrypt_hls` is on, the key/IV are handed to the daemon, which encrypts the HLS segments it serves and emits a matching `#EXT-X-KEY`.
-3. `HLSGenerator::tokenizeDaemonPlaylist()` rewrites the daemon playlist's segment URLs into per-segment auth'd `/hls/<token>` links that `segment.php` proxies from the daemon.
+1. `StreamProcess` writes the stream's AES-128 key/IV to `content/streams/<id>_.key` / `_.iv` — before it spawns a PHP producer, which registers with the daemon moments after starting.
+2. At ingest registration (`FanoutClient::registerIngest`), when `encrypt_hls` is on, the key/IV are handed to the daemon, which encrypts the HLS segments it serves. Every producer passes them — ffmpeg streams (loopback children included), supervised streams, and the PHP producers via `IngestFeeder::forStream()` — because the playlist always declares the key: a daemon fed without it served plain segments no player could decrypt.
+3. `HLSGenerator::tokenizeDaemonPlaylist()` rewrites the daemon playlist's segment URLs into per-segment auth'd `/hls/<token>` links that `segment.php` proxies from the daemon, and adds the `#EXT-X-KEY` line.
 4. The AES key is delivered to players by `key.php` (`src/Public/stream/key.php`) using the same token mechanism.
 
-> The legacy `HLSGenerator::generateHLS()` (which built and encrypted an on-disk HLS playlist for PHP to serve) is retained in the class but is **no longer on the client path** after the daemon cutover.
+The live playlist's `#EXT-X-MEDIA-SEQUENCE` is re-anchored by `HlsSequence` so it never steps back across an off-air ↔ live transition, without renumbering a stream that is playing (its state lives in `tmp/signals/hlsseq_<id>`, so it survives a stream restart).
 
 ---
 

--- a/lb_configs/nginx.conf
+++ b/lb_configs/nginx.conf
@@ -95,6 +95,9 @@ http {
             fastcgi_param SCRIPT_FILENAME /home/xc_vm/Public/stream/index.php;
             fastcgi_param SCRIPT_NAME /public/stream/index.php;
             fastcgi_param XC_STREAM $1;
+            # The TCP peer before real_ip rewrites REMOTE_ADDR to the client:
+            # auth checks it (not a client-set header) for proxy-only servers.
+            fastcgi_param XC_PEER_ADDR $realip_remote_addr;
         }
 
         # ─── Loopback handlers only → Admin Gateway ──────────────

--- a/src/Cli/Commands/DelayCommand.php
+++ b/src/Cli/Commands/DelayCommand.php
@@ -6,6 +6,7 @@ use XcVm\Cli\CommandInterface;
 use XcVm\Core\Config\SettingsManager;
 use XcVm\Core\Process\ProcessManager;
 use XcVm\Domain\Stream\StreamProcess;
+use XcVm\Streaming\Fanout\IngestFeeder;
 
 /**
  * DelayCommand — delay command
@@ -77,8 +78,22 @@ class DelayCommand implements CommandInterface {
 		if (file_exists($rPlaylistOld)) {
 			$rOldSegments = $this->getSegments($rPlaylistOld, -1);
 		}
+		// Clients are served only by the xc_fanout daemon (ADR 0003, Phase E), and a
+		// delayed stream's encoder output is the undelayed one — so nothing fed the
+		// daemon the delayed stream and a delayed channel could not be watched at
+		// all. The segments this worker publishes are now pushed into the daemon's
+		// ingest as they go out, paced over their duration so TS viewers get a
+		// steady stream; the daemon re-segments them for HLS.
+		$rFeeder = IngestFeeder::forStream($rStreamID, (bool) SettingsManager::get('encrypt_hls'), static function (string $rLine) use ($rStreamID) {
+			@file_put_contents(STREAMS_PATH . $rStreamID . '.errors', '[Delay] ' . $rLine . "\n", FILE_APPEND | LOCK_EX);
+		});
+		$rFeeder->connect();
+		$rFedSegment = null;
+		$rFeedQueue = array();
+		$rFeedCurrent = null;
+
 		$rPrevMD5 = null;
-		$rMD5 = md5(file_get_contents($rPlaylistDelay));
+		$rMD5 = md5((string) @file_get_contents($rPlaylistDelay));
 		while (ProcessManager::isStreamRunning($rPID, $rStreamID) && file_exists($rPlaylistDelay)) {
 			if ($rMD5 != $rPrevMD5) {
 				if (file_exists(STREAMS_PATH . $rStreamID . '_.dur')) {
@@ -103,16 +118,108 @@ class DelayCommand implements CommandInterface {
 						$rData .= '#EXTINF:' . $rSegment['seconds'] . ',' . "\n" . $rSegment['file'] . "\n";
 					}
 					file_put_contents($rPlaylist, $rData, LOCK_EX);
+					$this->queueForDaemon($rM3U8['segments'], $rFedSegment, $rFeedQueue);
 					$rMD5 = $rPrevMD5;
 					$this->deleteSegments($rStreamID, $rSequence - 2);
 					$this->cleanUpSegments($rStreamID, $rDelayDuration);
 				}
 			}
-			usleep(1000);
-			$rPrevMD5 = md5(file_get_contents($rPlaylistDelay));
+			$this->pumpDaemon($rFeeder, $rFeedQueue, $rFeedCurrent);
+			// 50 ms: fine enough to pace the daemon feed and to publish a new
+			// delayed segment promptly (this used to spin every 1 ms, hashing the
+			// playlist a thousand times a second).
+			usleep(50000);
+			$rPrevMD5 = md5((string) @file_get_contents($rPlaylistDelay));
 		}
 
+		$rFeeder->close(); // the daemon keeps the stream; viewers wait for the restart's feed
 		return 0;
+	}
+
+	/** Segments sent at once when the worker starts, so viewers get data immediately. */
+	private const FEED_SEED_SEGMENTS = 2;
+
+	/** Queued segments past which the feed stops pacing and catches up. */
+	private const FEED_BACKLOG_SEGMENTS = 3;
+
+	/**
+	 * Queue the segments just published that the daemon has not been fed yet (all
+	 * but the newest FEED_SEED_SEGMENTS are skipped on the worker's first pass).
+	 *
+	 * @param array    $rSegments  Published segments, oldest first ({seconds, file}).
+	 * @param int|null $rFedSegment Highest segment number queued so far.
+	 * @param array    $rQueue     Pending {data, dur, burst} entries.
+	 * @return void
+	 */
+	private function queueForDaemon(array $rSegments, ?int &$rFedSegment, array &$rQueue): void {
+		$rNew = array();
+		foreach ($rSegments as $rSegment) {
+			if (preg_match('/_(\d+)\.ts$/', (string) ($rSegment['file'] ?? ''), $rMatch)) {
+				$rNumber = intval($rMatch[1]);
+				if ($rFedSegment === null || $rNumber > $rFedSegment) {
+					$rNew[$rNumber] = $rSegment;
+				}
+			}
+		}
+		if (count($rNew) === 0) {
+			return;
+		}
+		ksort($rNew);
+		$rSeed = ($rFedSegment === null);
+		if ($rSeed) {
+			$rNew = array_slice($rNew, -self::FEED_SEED_SEGMENTS, null, true);
+		}
+		foreach ($rNew as $rNumber => $rSegment) {
+			$rData = @file_get_contents(STREAMS_PATH . $rSegment['file']);
+			if (!is_string($rData) || $rData === '') {
+				$rData = @file_get_contents(DELAY_PATH . $rSegment['file']);
+			}
+			if (is_string($rData) && strlen($rData) >= 188) {
+				$rData = substr($rData, 0, strlen($rData) - strlen($rData) % 188); // whole packets
+				$rQueue[] = array('data' => $rData, 'dur' => max(0.5, floatval($rSegment['seconds'])), 'burst' => $rSeed);
+			}
+			$rFedSegment = $rNumber;
+		}
+	}
+
+	/**
+	 * Feed the daemon: the current segment is released in whole packets spread
+	 * over 90% of its duration (so the feed never falls behind the playlist); the
+	 * start-up seed, or a backlog of queued segments, is sent at once.
+	 *
+	 * @param IngestFeeder $rFeeder  The daemon feed.
+	 * @param array        $rQueue   Pending {data, dur, burst} entries.
+	 * @param array|null   $rCurrent The segment being paced ({data, sent, start, dur, burst}).
+	 * @return void
+	 */
+	private function pumpDaemon(IngestFeeder $rFeeder, array &$rQueue, ?array &$rCurrent): void {
+		$rNow = microtime(true);
+		if ($rCurrent === null && count($rQueue) > 0) {
+			$rItem = array_shift($rQueue);
+			$rCurrent = array('data' => $rItem['data'], 'sent' => 0, 'start' => $rNow, 'dur' => $rItem['dur'], 'burst' => $rItem['burst']);
+		}
+		if ($rCurrent === null) {
+			$rFeeder->flush();
+			return;
+		}
+
+		$rLength = strlen($rCurrent['data']);
+		if ($rCurrent['burst'] || count($rQueue) >= self::FEED_BACKLOG_SEGMENTS) {
+			$rTarget = $rLength;
+		} else {
+			$rTarget = (int) min($rLength, ceil($rLength * ($rNow - $rCurrent['start']) / ($rCurrent['dur'] * 0.9)));
+			$rTarget -= $rTarget % 188;
+		}
+		$rChunk = $rTarget - $rCurrent['sent'];
+		if ($rChunk > 0) {
+			$rFeeder->write(substr($rCurrent['data'], $rCurrent['sent'], $rChunk));
+			$rCurrent['sent'] += $rChunk;
+		} else {
+			$rFeeder->flush();
+		}
+		if ($rCurrent['sent'] >= $rLength) {
+			$rCurrent = null;
+		}
 	}
 
 	private function cleanUpSegments($rStreamID, $rDelayDuration): void {

--- a/src/Cli/Commands/FanoutSyncCommand.php
+++ b/src/Cli/Commands/FanoutSyncCommand.php
@@ -40,6 +40,9 @@ class FanoutSyncCommand implements CommandInterface {
 	/** Reconcile interval, seconds. */
 	private const INTERVAL = 10;
 
+	/** @var array<string,int> Daemon viewer uuid => when it was first seen without a row. */
+	private array $rOrphanSince = array();
+
 	public function getName(): string {
 		return 'fanout_sync';
 	}
@@ -79,8 +82,11 @@ class FanoutSyncCommand implements CommandInterface {
 			$rActive = FanoutClient::activeConnections();
 			if ($rActive !== null) {
 				$rConns = $this->daemonConnections();
-				$this->reconcile(array_flip($rActive), $rConns);
-				$this->writeDivergence($rConns);
+				if ($rConns !== null) {
+					$this->reconcile(array_flip($rActive), $rConns);
+					$this->dropOrphans($rActive, $rConns);
+					$this->writeDivergence($rConns);
+				}
 			}
 
 			sleep(self::INTERVAL);
@@ -127,6 +133,53 @@ class FanoutSyncCommand implements CommandInterface {
 				ConnectionTracker::closeConnection($rConn);
 			}
 		}
+	}
+
+	/**
+	 * The other direction of reconcile(): end daemon viewers that have no open row
+	 * any more. Every path that closes a connection by deleting its row — the
+	 * reaper, an expired or banned line, a limit eviction on a node that could not
+	 * reach this daemon — would otherwise leave the viewer streaming, untracked
+	 * and uncounted. A uuid must stay orphaned for GRACE before it is dropped (the
+	 * row is written before the X-Accel hand-off, so a live viewer always has one;
+	 * the grace covers a read racing that write).
+	 *
+	 * @param string[]                       $rActive Uuids connected to the daemon.
+	 * @param array<int,array<string,mixed>> $rConns  Open rows on this server.
+	 * @param int|null                       $rNow    Current time (tests), default now.
+	 * @param callable|null                  $rDrop   fn(string $uuid) (tests), default the daemon call.
+	 * @return string[] The uuids dropped on this pass.
+	 */
+	public function dropOrphans(array $rActive, array $rConns, ?int $rNow = null, ?callable $rDrop = null): array {
+		$rKnown = array();
+		foreach ($rConns as $rConn) {
+			if (is_array($rConn) && !empty($rConn['uuid']) && empty($rConn['hls_end'])) {
+				$rKnown[$rConn['uuid']] = true;
+			}
+		}
+
+		$rNow = $rNow ?? time();
+		$rDrop = $rDrop ?? static function (string $rUUID): void {
+			FanoutClient::dropConnection($rUUID);
+		};
+		$rSeen = array();
+		$rDropped = array();
+		foreach ($rActive as $rUUID) {
+			$rUUID = (string) $rUUID;
+			if ($rUUID === '' || isset($rKnown[$rUUID])) {
+				continue;
+			}
+			$rSince = $this->rOrphanSince[$rUUID] ?? $rNow;
+			if ($rNow - $rSince >= self::GRACE) {
+				echo 'Dropping daemon viewer without a connection row: ' . $rUUID . "\n";
+				$rDrop($rUUID);
+				$rDropped[] = $rUUID;
+				continue;
+			}
+			$rSeen[$rUUID] = $rSince;
+		}
+		$this->rOrphanSince = $rSeen;
+		return $rDropped;
 	}
 
 	/**
@@ -215,21 +268,27 @@ class FanoutSyncCommand implements CommandInterface {
 
 	/**
 	 * Candidate daemon-served rows (pid=0, open) on this server, from Redis or DB.
+	 * Null when they could not be read — distinct from "none", which would have
+	 * dropOrphans() disconnect every daemon viewer on a Redis or database blip.
 	 *
-	 * @return array<int,array<string,mixed>>
+	 * @return array<int,array<string,mixed>>|null
 	 */
-	private function daemonConnections(): array {
+	private function daemonConnections(): ?array {
 		global $rSettings;
 
 		if (!empty($rSettings['redis_handler'])) {
 			RedisManager::ensureConnected();
 			$rRedis = RedisManager::instance();
 			if (!$rRedis) {
-				return array();
+				return null;
 			}
-			$rKeys = $rRedis->zRangeByScore('SERVER#' . SERVER_ID, '-inf', '+inf');
+			try {
+				$rKeys = $rRedis->zRangeByScore('SERVER#' . SERVER_ID, '-inf', '+inf');
+			} catch (\Throwable $rError) {
+				return null;
+			}
 			if (!is_array($rKeys)) {
-				return array();
+				return null;
 			}
 			$rOut = array();
 			foreach ($rKeys as $rUUID) {
@@ -243,7 +302,9 @@ class FanoutSyncCommand implements CommandInterface {
 
 		DatabaseFactory::connect();
 		global $db;
-		$db->query('SELECT * FROM `lines_live` WHERE `server_id` = ? AND `pid` = 0 AND `hls_end` = 0', SERVER_ID);
+		if (!$db->query('SELECT * FROM `lines_live` WHERE `server_id` = ? AND `pid` = 0 AND `hls_end` = 0', SERVER_ID)) {
+			return null;
+		}
 		return $db->get_rows();
 	}
 }

--- a/src/Cli/Commands/LlodCommand.php
+++ b/src/Cli/Commands/LlodCommand.php
@@ -451,11 +451,13 @@ class LlodCommand implements CommandInterface {
 	 */
 	private function sourceContext($rURL, $rStreamArguments, $rRequestPrebuffer) {
 		$rArg = static function (string $rKey) use ($rStreamArguments): string {
-			$rValue = $rStreamArguments[$rKey]['value'] ?? '';
-			if ($rValue === '' || $rValue === null) {
-				$rValue = $rStreamArguments[$rKey]['argument_default_value'] ?? '';
+			// `??` already maps a missing or null value to '': an empty value
+			// (after trimming) falls back to the argument's default.
+			$rValue = trim((string) ($rStreamArguments[$rKey]['value'] ?? ''));
+			if ($rValue === '') {
+				$rValue = trim((string) ($rStreamArguments[$rKey]['argument_default_value'] ?? ''));
 			}
-			return trim((string) $rValue);
+			return $rValue;
 		};
 
 		$rHeaders = array();

--- a/src/Cli/Commands/LlodCommand.php
+++ b/src/Cli/Commands/LlodCommand.php
@@ -3,7 +3,10 @@
 namespace XcVm\Cli\Commands;
 
 use XcVm\Cli\CommandInterface;
+use XcVm\Core\Process\ProcessManager;
+use XcVm\Core\Util\StreamUtils;
 use XcVm\Streaming\Fanout\FanoutClient;
+use XcVm\Streaming\Fanout\IngestFeeder;
 
 /**
  * LlodCommand — llod command
@@ -112,12 +115,12 @@ class LlodCommand implements CommandInterface {
 
 		echo "Starting LLOD processing...\n\n";
 
-		$this->startLlod($rStreamID, $rStreamSources, $rStreamArguments, $rRequestPrebuffer, $rSegListSize, $rSegDeleteThreshold, $rSegTime, $rSegmentStatus, $rFP, $rSegmentFile);
+		$this->startLlod($rStreamID, $rStreamSources, $rStreamArguments, $rRequestPrebuffer, $rSegListSize, $rSegDeleteThreshold, $rSegTime, !empty($rSettings['encrypt_hls']), $rSegmentStatus, $rFP, $rSegmentFile);
 
 		return 0;
 	}
 
-	private function startLlod($rStreamID, $rStreamSources, $rStreamArguments, $rRequestPrebuffer, $rSegListSize, $rSegDeleteThreshold, $rSegTime, &$rSegmentStatus, &$rFP, &$rSegmentFile): void {
+	private function startLlod($rStreamID, $rStreamSources, $rStreamArguments, $rRequestPrebuffer, $rSegListSize, $rSegDeleteThreshold, $rSegTime, $rEncryptHLS, &$rSegmentStatus, &$rFP, &$rSegmentFile): void {
 		// Keyframe-aligned segmentation. The previous version cut segments on a
 		// fixed wall-clock timer (SEGMENT_DURATION) at an arbitrary TS-packet
 		// boundary, so a segment frequently started mid-GOP (no IDR keyframe) or
@@ -139,20 +142,8 @@ class LlodCommand implements CommandInterface {
 			}
 		}
 
-		$ua = $rStreamArguments['user_agent']['value'] ?? 'Mozilla/5.0';
-
-		$context = stream_context_create([
-			'http' => [
-				'timeout'    => TIMEOUT,
-				'user_agent' => $ua,
-			],
-			'ssl' => [
-				'verify_peer'      => false,
-				'verify_peer_name' => false,
-			]
-		]);
-
-		$rFP = $this->getActiveStream($rStreamID, $rStreamSources, $context);
+		$rSniffed = '';
+		$rFP = $this->getActiveStream($rStreamID, $rStreamSources, $rStreamArguments, $rRequestPrebuffer, $rSniffed);
 		if (!$rFP) {
 			echo "No active stream\n";
 			return;
@@ -160,21 +151,19 @@ class LlodCommand implements CommandInterface {
 
 		stream_set_blocking($rFP, true);
 
-		// LLOD v3 daemon feed (ADR 0003). LLOD reads MPEG-TS itself (no ffmpeg),
-		// so mirror the raw bytes into the xc_fanout daemon's push-fed ingest
-		// socket — the same stream then fans out via /live/<id> and in-RAM /hls,
-		// and live.php's isStreamFed() routes viewers to the daemon. The write is
-		// non-blocking + best-effort so a daemon stall never slows LLOD's own
-		// segmenting (its primary job); the daemon resyncs on PAT/PMT after any
-		// dropped bytes. Null / failed connect ⇒ legacy-only, no behaviour change.
-		$rDaemonSock = FanoutClient::registerIngest($rStreamID);
-		$rDaemonConn = null;
-		if ($rDaemonSock !== null) {
-			$rDaemonConn = @stream_socket_client('unix://' . $rDaemonSock, $rDErrno, $rDErrstr, 2);
-			if ($rDaemonConn) {
-				stream_set_blocking($rDaemonConn, false);
-			}
-		}
+		// LLOD v3 daemon feed (ADR 0003). LLOD reads MPEG-TS itself (no ffmpeg) and
+		// pushes it into the xc_fanout daemon's ingest socket: the daemon is what
+		// serves this channel's viewers (/live/<id> and the in-RAM /hls) — there is
+		// no other client path since Phase E, so the feed is the delivery, and the
+		// on-disk segments below only serve timeshift/thumbnails/the monitor.
+		// IngestFeeder keeps short writes from tearing packets, re-registers and
+		// redials after a daemon restart, and carries the HLS key when encrypted
+		// HLS is on (the playlist declares it; without the key the daemon served
+		// plain segments no player could decrypt).
+		$rFeeder = IngestFeeder::forStream($rStreamID, !empty($rEncryptHLS), function (string $rLine) use ($rStreamID) {
+			$this->writeError($rStreamID, '[LLOD] ' . $rLine);
+		});
+		$rFeeder->connect();
 
 		shell_exec('rm -f ' . STREAMS_PATH . escapeshellarg($rStreamID) . '_*.ts');
 
@@ -191,12 +180,13 @@ class LlodCommand implements CommandInterface {
 
 		$lastData    = time();
 		$firstDataAt = microtime(true);
-		$buffer      = '';
+		$buffer      = $rSniffed; // bytes read while identifying the source as MPEG-TS
 
 		while (!feof($rFP)) {
 			$data = fread($rFP, BUFFER_SIZE);
 
 			if ($data === '' || $data === false) {
+				$rFeeder->flush(); // drain a backlog / reconnect while the source is quiet
 				if (time() - $lastData > TIMEOUT) {
 					$this->writeError($rStreamID, '[LLOD] stream timeout');
 					break;
@@ -208,17 +198,9 @@ class LlodCommand implements CommandInterface {
 			$lastData = time();
 			$buffer  .= $data;
 
-			// Mirror to the daemon (best-effort, non-blocking). On a write error
-			// (daemon gone) stop mirroring; live.php then falls back to legacy.
-			if ($rDaemonConn) {
-				if (@fwrite($rDaemonConn, $data) === false) {
-					@fclose($rDaemonConn);
-					$rDaemonConn = null;
-				}
-			}
-
 			$len = strlen($buffer);
 			$off = 0;
+			$rFeed = ''; // whole packets for the daemon
 
 			// Process only whole 188-byte TS packets; keep any remainder buffered.
 			while ($len - $off >= PACKET_SIZE) {
@@ -239,6 +221,7 @@ class LlodCommand implements CommandInterface {
 
 				$pkt = substr($buffer, $off, PACKET_SIZE);
 				$off += PACKET_SIZE;
+				$rFeed .= $pkt; // every aligned packet goes to the daemon, from the first
 
 				$hdr = $this->parseTsHeader($pkt);
 				$pid = $hdr['pid'];
@@ -304,6 +287,8 @@ class LlodCommand implements CommandInterface {
 				fwrite($rSegmentFile, $pkt);
 			}
 
+			$rFeeder->write($rFeed);
+
 			// Retain the partial trailing packet for the next read.
 			$buffer = ($off >= $len) ? '' : substr($buffer, $off);
 		}
@@ -314,9 +299,7 @@ class LlodCommand implements CommandInterface {
 		if (is_resource($rFP)) {
 			fclose($rFP);
 		}
-		if (is_resource($rDaemonConn)) {
-			fclose($rDaemonConn);
-		}
+		$rFeeder->close();
 		// Drop the daemon ingest on a clean exit; stopStream() is the backstop
 		// when LLOD is killed mid-loop.
 		FanoutClient::unregister($rStreamID);
@@ -454,13 +437,93 @@ class LlodCommand implements CommandInterface {
 		return $pcrPid !== 0x1FFF ? $pcrPid : null;
 	}
 
-	private function getActiveStream($rStreamID, $rURLs, $rContext) {
+	/**
+	 * The HTTP stream context for one source, from the stream's fetch arguments —
+	 * the same user agent, extra headers, cookie and proxy the ffmpeg path sends
+	 * (it used to send only a user agent, and no default one when the argument
+	 * was left empty), plus the prebuffer request an XC_VM source understands
+	 * when request_prebuffer is on.
+	 *
+	 * @param string $rURL              Source URL.
+	 * @param array  $rStreamArguments  argument_key => {value, argument_default_value}.
+	 * @param mixed  $rRequestPrebuffer The request_prebuffer setting.
+	 * @return resource
+	 */
+	private function sourceContext($rURL, $rStreamArguments, $rRequestPrebuffer) {
+		$rArg = static function (string $rKey) use ($rStreamArguments): string {
+			$rValue = $rStreamArguments[$rKey]['value'] ?? '';
+			if ($rValue === '' || $rValue === null) {
+				$rValue = $rStreamArguments[$rKey]['argument_default_value'] ?? '';
+			}
+			return trim((string) $rValue);
+		};
+
+		$rHeaders = array();
+		foreach (preg_split('/\r\n|\r|\n/', $rArg('headers')) as $rLine) {
+			if (trim($rLine) !== '' && strpos($rLine, ':') !== false) {
+				$rHeaders[] = trim($rLine);
+			}
+		}
+		if ($rArg('cookie') !== '') {
+			$rHeaders[] = 'Cookie: ' . $rArg('cookie');
+		}
+		if (!empty($rRequestPrebuffer) && StreamUtils::detectXC_VM($rURL)) {
+			$rHeaders[] = 'X-XC_VM-Prebuffer: 1';
+		}
+
+		$rHTTP = array(
+			'timeout'    => TIMEOUT,
+			'user_agent' => ($rArg('user_agent') !== '' ? $rArg('user_agent') : 'Mozilla/5.0'),
+		);
+		if (count($rHeaders) > 0) {
+			$rHTTP['header'] = implode("\r\n", $rHeaders);
+		}
+		$rProxy = $rArg('proxy');
+		if ($rProxy !== '') {
+			$rHTTP['proxy'] = (strpos($rProxy, '://') === false ? 'tcp://' : '') . $rProxy;
+			$rHTTP['request_fulluri'] = true;
+		}
+
+		return stream_context_create(array(
+			'http' => $rHTTP,
+			'ssl'  => array('verify_peer' => false, 'verify_peer_name' => false),
+		));
+	}
+
+	/**
+	 * Read up to $rLength bytes from a just-opened source to recognise MPEG-TS by
+	 * its content: two sync bytes one packet apart.
+	 *
+	 * @param resource $rFP     Source stream.
+	 * @param string   $rSniffed Receives the bytes read (they are part of the stream).
+	 * @return bool
+	 */
+	private function looksLikeMpegTs($rFP, string &$rSniffed): bool {
+		$rSniffed = '';
+		$rDeadline = time() + TIMEOUT;
+		while (strlen($rSniffed) < PACKET_SIZE * 4 && !feof($rFP) && time() < $rDeadline) {
+			$rChunk = fread($rFP, PACKET_SIZE * 4 - strlen($rSniffed));
+			if ($rChunk === false || $rChunk === '') {
+				usleep(10000);
+				continue;
+			}
+			$rSniffed .= $rChunk;
+		}
+		for ($i = 0; $i + PACKET_SIZE < strlen($rSniffed) && $i < PACKET_SIZE; $i++) {
+			if ($rSniffed[$i] === "\x47" && $rSniffed[$i + PACKET_SIZE] === "\x47") {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function getActiveStream($rStreamID, $rURLs, $rStreamArguments, $rRequestPrebuffer, string &$rSniffed) {
 		echo "Trying to get active stream from " . count($rURLs) . " URL(s)\n";
 
 		foreach ($rURLs as $index => $rURL) {
 			echo "\nAttempting source " . ($index + 1) . "/" . count($rURLs) . ": $rURL\n";
 
-			$rFP = @fopen($rURL, 'rb', false, $rContext);
+			$rFP = @fopen($rURL, 'rb', false, $this->sourceContext($rURL, $rStreamArguments, $rRequestPrebuffer));
 
 			if ($rFP) {
 				echo "Connection successful\n";
@@ -490,7 +553,13 @@ class LlodCommand implements CommandInterface {
 					echo "  $key: $value\n";
 				}
 
-				$rContentType = $rHeaders['Content-Type'] ?? '';
+				// Header names are case-insensitive (HTTP/2-style lower-case is common).
+				$rContentType = '';
+				foreach ($rHeaders as $rKey => $rValue) {
+					if (is_string($rKey) && strcasecmp($rKey, 'Content-Type') === 0) {
+						$rContentType = $rValue;
+					}
+				}
 				echo "Content-Type: $rContentType\n";
 
 				if (stripos($rContentType, 'video/mp2t') !== false) {
@@ -499,7 +568,17 @@ class LlodCommand implements CommandInterface {
 					return $rFP;
 				}
 
-				$contentTypeInfo = $rHeaders['Content-Type'] ?? 'unknown';
+				// Many TS sources label it application/octet-stream, or nothing at
+				// all: recognise it by content rather than refusing a playable
+				// source. An HLS playlist or an HTML error page fails the check.
+				if ($this->looksLikeMpegTs($rFP, $rSniffed)) {
+					echo "Content is MPEG-TS (labelled '$rContentType')\n";
+					echo "=== getActiveStream() successful ===\n\n";
+					return $rFP;
+				}
+				$rSniffed = '';
+
+				$contentTypeInfo = ($rContentType !== '' ? $rContentType : 'unknown');
 				$this->writeError($rStreamID, "[LLOD] Source isn't MPEG-TS: " . $rURL . ' - ' . $contentTypeInfo);
 				fclose($rFP);
 			} else {
@@ -596,7 +675,11 @@ class LlodCommand implements CommandInterface {
 			$m3u8 .= "{$rStreamID}_{$seg}.ts\n";
 		}
 
-		if (@file_put_contents(STREAMS_PATH . $rStreamID . '_.m3u8', $m3u8, LOCK_EX) === false) {
+		// Write-then-rename: readers (the monitor's staleness check, thumbnails,
+		// timeshift) never see a half-written playlist.
+		$rTmp = STREAMS_PATH . $rStreamID . '_.m3u8.tmp';
+		if (@file_put_contents($rTmp, $m3u8) === false || !@rename($rTmp, STREAMS_PATH . $rStreamID . '_.m3u8')) {
+			@unlink($rTmp);
 			$this->writeError($rStreamID, '[LLOD] Failed to write playlist file');
 			return;
 		}
@@ -611,41 +694,18 @@ class LlodCommand implements CommandInterface {
 		@file_put_contents(STREAMS_PATH . $rStreamID . '.errors', $logMessage, FILE_APPEND | LOCK_EX);
 	}
 
+	/**
+	 * One segmenter per stream: end any other LLOD process for this stream (one a
+	 * killed monitor left behind). This used to read `_.monitor`, which holds the
+	 * MONITOR's pid — never an LLOD one — so an old segmenter was never found and
+	 * two could write the same segment files and feed the daemon at once.
+	 */
 	private function checkRunning($rStreamID): void {
 		echo "Checking for existing process for stream $rStreamID\n";
-		clearstatcache(true);
-		$monitorFile = STREAMS_PATH . $rStreamID . '_.monitor';
-		$rPID = null;
-		if (file_exists($monitorFile)) {
-			$rPID = intval(file_get_contents($monitorFile));
-			echo "Monitor file found, PID: $rPID\n";
-		} else {
-			echo "No monitor file found\n";
-		}
-		if (empty($rPID)) {
-			$killCmd = "kill -9 `ps -ef | grep 'LLOD\\[" . intval($rStreamID) . "\\]' | grep -v grep | awk '{print \$2}'`";
-			echo "No PID from monitor, executing kill command: $killCmd\n";
-			shell_exec($killCmd);
-		} else {
-			if (file_exists('/proc/' . $rPID)) {
-				echo "Process directory exists: /proc/$rPID\n";
-				$cmdlineFile = '/proc/' . $rPID . '/cmdline';
-				if (file_exists($cmdlineFile)) {
-					$rCommand = trim(file_get_contents($cmdlineFile));
-					echo "Process command line: $rCommand\n";
-					$expectedCommand = 'LLOD[' . $rStreamID . ']';
-					if ($rCommand === $expectedCommand && 0 < $rPID) {
-						echo "Killing existing process PID: $rPID\n";
-						posix_kill($rPID, 9);
-					} else {
-						echo "Process command doesn't match expected: '$rCommand' != '$expectedCommand'\n";
-					}
-				} else {
-					echo "Command line file not found\n";
-				}
-			} else {
-				echo "Process directory doesn't exist, process not running\n";
-			}
+		$rTerms = array('LLOD[' . intval($rStreamID) . ']', 'console.php llod ' . intval($rStreamID) . ' ');
+		foreach (ProcessManager::findProcessPIDs($rTerms) as $rPID) {
+			echo "Killing existing LLOD process PID: $rPID\n";
+			@posix_kill($rPID, 9);
 		}
 	}
 }

--- a/src/Cli/Commands/LoopbackCommand.php
+++ b/src/Cli/Commands/LoopbackCommand.php
@@ -5,6 +5,7 @@ namespace XcVm\Cli\Commands;
 use XcVm\Cli\CommandInterface;
 use XcVm\Core\Config\ConfigReader;
 use XcVm\Streaming\Fanout\FanoutClient;
+use XcVm\Streaming\Fanout\IngestFeeder;
 
 /**
  * LoopbackCommand — loopback command
@@ -127,24 +128,18 @@ class LoopbackCommand implements CommandInterface {
 		stream_set_blocking($rFP, true);
 
 		// Loopback daemon feed (ADR 0003, Phase G restream-from-origin). Loopback
-		// reads MPEG-TS from the parent server itself (no ffmpeg), so — like LLOD v3
-		// — mirror the bytes into the xc_fanout daemon's push-fed ingest socket: the
-		// same stream then fans out via /live/<id> and in-RAM /hls on this LB, and
-		// live.php's isStreamFed() routes viewers to the daemon instead of the PHP
-		// byte path (the whole point on an LB too). The write is non-blocking +
-		// best-effort so a daemon stall never slows loopback's own segmenting; the
-		// daemon resyncs on PAT/PMT after any dropped bytes. Null/failed connect ⇒
-		// legacy-only, no behaviour change. We mirror the SANITIZED buffer (below),
-		// not the raw read, because admin/live interleaves 0xFF padding that would
-		// otherwise break the daemon's packet parsing.
-		$rDaemonSock = FanoutClient::registerIngest($rStreamID);
-		$rDaemonConn = null;
-		if ($rDaemonSock !== null) {
-			$rDaemonConn = @stream_socket_client('unix://' . $rDaemonSock, $rDErrno, $rDErrstr, 2);
-			if ($rDaemonConn) {
-				stream_set_blocking($rDaemonConn, false);
-			}
-		}
+		// reads MPEG-TS from the parent server itself (no ffmpeg) and pushes it into
+		// the xc_fanout daemon's ingest socket; the daemon is what serves this LB's
+		// viewers (/live/<id> and the in-RAM /hls) — there is no other client path
+		// since Phase E, so this feed is the channel's delivery. IngestFeeder keeps
+		// short writes from tearing packets, re-registers and redials after a daemon
+		// restart, and carries the HLS key when encrypted HLS is on. We feed the
+		// SANITIZED buffer (below), not the raw read, because admin/live interleaves
+		// 0xFF padding that would otherwise break the daemon's packet parsing.
+		$rFeeder = IngestFeeder::forStream($rStreamID, !empty($rSettings['encrypt_hls']), function (string $rLine) use ($rStreamID) {
+			$this->writeError($rStreamID, '[Loopback] ' . $rLine);
+		});
+		$rFeeder->connect();
 
 		$rExcessBuffer = $rPrebuffer = $rBuffer = $rPacket = '';
 		$rPATHeaders = array();
@@ -207,16 +202,12 @@ class LoopbackCommand implements CommandInterface {
 				}
 			}
 			$rPacketNum = floor(strlen($rBuffer) / PACKET_SIZE);
+			if (0 == $rPacketNum) {
+				$rFeeder->flush(); // drain a backlog / reconnect even when nothing new arrived
+			}
 			if (0 < $rPacketNum) {
-				// Mirror the sanitized whole-packet buffer to the daemon (best-effort,
-				// non-blocking). On a write error (daemon gone) stop mirroring; viewers
-				// then fall back to the legacy on-disk HLS this loop still writes.
-				if ($rDaemonConn) {
-					if (@fwrite($rDaemonConn, $rBuffer) === false) {
-						@fclose($rDaemonConn);
-						$rDaemonConn = null;
-					}
-				}
+				// Feed the sanitized whole-packet buffer to the daemon (see above).
+				$rFeeder->write($rBuffer);
 				foreach (str_split($rBuffer, PACKET_SIZE) as $rPacket) {
 					list(, $rHeader) = unpack('N', substr($rPacket, 0, 4));
 					$rSync = $rHeader >> 24 & 255;
@@ -318,9 +309,7 @@ class LoopbackCommand implements CommandInterface {
 		if (time() - $rLastPacket < TIMEOUT) {
 			$this->writeError($rStreamID, '[Loopback] Connection to source closed unexpectedly.');
 		}
-		if ($rDaemonConn) {
-			@fclose($rDaemonConn);
-		}
+		$rFeeder->close();
 		FanoutClient::unregister($rStreamID);
 		fclose($rSegmentFile);
 		fclose($rFP);
@@ -382,7 +371,11 @@ class LoopbackCommand implements CommandInterface {
 				$rHLS .= '#EXTINF:' . round((isset($rSegmentDuration[$rSegment]) ? $rSegmentDuration[$rSegment] : 10), 0) . '.000000,' . "\n" . $rStreamID . '_' . $rSegment . '.ts' . "\n";
 			}
 		}
-		file_put_contents(STREAMS_PATH . $rStreamID . '_.m3u8', $rHLS);
+		// Write-then-rename: readers never see a half-written playlist.
+		$rTmp = STREAMS_PATH . $rStreamID . '_.m3u8.tmp';
+		if (@file_put_contents($rTmp, $rHLS) === false || !@rename($rTmp, STREAMS_PATH . $rStreamID . '_.m3u8')) {
+			@unlink($rTmp);
+		}
 	}
 
 	private function writeError($rStreamID, $rError): void {

--- a/src/Cli/Commands/MonitorCommand.php
+++ b/src/Cli/Commands/MonitorCommand.php
@@ -217,7 +217,7 @@ class MonitorCommand implements CommandInterface {
 								} else {
 									$rBaselineFps = $rFps;
 								}
-							} elseif ($rBaselineFps && (($rFps * ($rStreamInfo['fps_threshold'] ?: 100)) < $rBaselineFps)) {
+							} elseif ($rBaselineFps && self::isFpsBelowThreshold($rFps, $rBaselineFps, $rStreamInfo['fps_threshold'])) {
 								echo "FPS dropped below threshold! Break\n";
 								StreamProcess::streamLog($rStreamID, SERVER_ID, 'FPS_DROP_THRESHOLD', $rCurrentSource);
 								break;
@@ -265,8 +265,8 @@ class MonitorCommand implements CommandInterface {
 						$rBackupsChecked = time();
 						$rKey = array_search($rCurrentSource, $rSources);
 						if ((!is_numeric($rKey) || (0 < $rKey))) {
-							foreach ($rSources as $rSource) {
-								if (!(($rSource == $rCurrentSource) || ($rSource == $rForceSource))) {
+							foreach (self::higherPrioritySources($rSources, $rCurrentSource) as $rSource) {
+								if ($rSource != $rForceSource) {
 									$rStreamSource = StreamUtils::parseStreamURL($rSource);
 									$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
 									$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
@@ -284,8 +284,9 @@ class MonitorCommand implements CommandInterface {
 					}
 					if ((file_exists(SIGNALS_TMP_PATH . $rStreamID . '.force') && ($rParentID == 0))) {
 						$rForceID = intval(file_get_contents(SIGNALS_TMP_PATH . $rStreamID . '.force'));
-						$rStreamSource = StreamUtils::parseStreamURL($rSources[$rForceID]);
-						if (($rSources[$rForceID] != $rCurrentSource)) {
+						// A stale signal can name a source index that no longer exists.
+						$rStreamSource = isset($rSources[$rForceID]) ? StreamUtils::parseStreamURL($rSources[$rForceID]) : null;
+						if ($rStreamSource !== null && ($rSources[$rForceID] != $rCurrentSource)) {
 							$rProtocol = strtolower(substr($rStreamSource, 0, strpos($rStreamSource, '://')));
 							$rArguments = implode(' ', StreamUtils::getArguments($rStreamArguments, $rProtocol, 'fetch'));
 							if (($rProbe = FFprobeRunner::probeStream($rStreamSource, $rArguments))) {
@@ -365,6 +366,13 @@ class MonitorCommand implements CommandInterface {
 						$rMaxFails++;
 						if (((0 < SettingsManager::get('stop_failures')) && ($rMaxFails >= SettingsManager::get('stop_failures')))) {
 							echo "Failure limit reached, exiting.\n";
+							return 0;
+						}
+						// An on-demand source that cannot even be probed is a failed
+						// start like any other: honour on_demand_failure_exit here too,
+						// instead of re-probing a dead source until the cron stops it.
+						if (SettingsManager::get('on_demand_failure_exit') && $rStreamInfo['on_demand']) {
+							echo "On-demand source failed to probe, exiting.\n";
 							return 0;
 						}
 						echo 'Stream start failed (attempt ' . $rMaxFails . '). Sleeping ' . SettingsManager::get('stream_fail_sleep') . " seconds...\n";
@@ -490,6 +498,40 @@ class MonitorCommand implements CommandInterface {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Whether the current frame rate fell below the stream's threshold — a
+	 * percentage of its baseline ("FPS Threshold %", 90 when unset, the same
+	 * default the fanout supervisor applies). The comparison used to multiply the
+	 * current rate by the percentage without dividing by 100, so it only fired
+	 * below ~1% of the baseline — never, in practice.
+	 *
+	 * @param float $rFps       Current frames per second.
+	 * @param float $rBaseline  Baseline frames per second.
+	 * @param mixed $rThreshold fps_threshold percentage (1..100), or empty.
+	 * @return bool
+	 */
+	public static function isFpsBelowThreshold($rFps, $rBaseline, $rThreshold): bool {
+		$rPercent = min(100, max(1, intval($rThreshold) ?: 90));
+		return 0 < $rBaseline && $rFps < $rBaseline * $rPercent / 100;
+	}
+
+	/**
+	 * The sources ranked above the one in use, in priority order — the only ones
+	 * priority backup may switch back to. Checking every other source let a
+	 * stream on backup B move DOWN to backup C whenever the primary was still out.
+	 *
+	 * @param array $rSources       Ordered source list (primary first).
+	 * @param mixed $rCurrentSource The source in use.
+	 * @return array
+	 */
+	public static function higherPrioritySources(array $rSources, $rCurrentSource): array {
+		$rKey = array_search($rCurrentSource, $rSources);
+		if (!is_numeric($rKey)) {
+			return array_values($rSources); // current is not in the list (e.g. it was edited): all are candidates
+		}
+		return array_slice(array_values($rSources), 0, (int) $rKey);
 	}
 
 	/**

--- a/src/Cli/Commands/SignalsCommand.php
+++ b/src/Cli/Commands/SignalsCommand.php
@@ -8,6 +8,7 @@ use XcVm\Core\Config\SettingsManager;
 use XcVm\Domain\Server\ServerRepository;
 use XcVm\Domain\Stream\StreamProcess;
 use XcVm\Infrastructure\Redis\RedisManager;
+use XcVm\Streaming\Fanout\FanoutClient;
 
 /**
  * SignalsCommand — signals command
@@ -134,6 +135,11 @@ class SignalsCommand implements CommandInterface {
 									// suppress the harmless "No such file" warning.
 									@unlink(CONS_TMP_PATH . $rCustomData['uuid']);
 									break;
+								case 'drop_con':
+									// A daemon-served viewer on this node was kicked
+									// from another (ConnectionTracker::dropDaemonViewer).
+									FanoutClient::dropConnection((string) ($rCustomData['uuid'] ?? ''));
+									break;
 								case 'delete_vod':
 									exec('rm ' . MAIN_HOME . 'content/vod/' . intval($rCustomData['id']) . '.*');
 									break;
@@ -168,7 +174,9 @@ class SignalsCommand implements CommandInterface {
 								$rRow = igbinary_unserialize($rData);
 								$rIDs[] = $rRow['key'];
 								$rPID = $rRow['pid'];
-								if ($rRow['rtmp'] == 0) {
+								if (is_array($rRow['custom_data'] ?? null) && ($rRow['custom_data']['type'] ?? '') === 'drop_con') {
+									FanoutClient::dropConnection((string) ($rRow['custom_data']['uuid'] ?? ''));
+								} elseif ($rRow['rtmp'] == 0) {
 									if (!empty($rPID) && file_exists('/proc/' . $rPID) && is_numeric($rPID) && 0 < $rPID) {
 										shell_exec('kill -9 ' . intval($rPID));
 									}

--- a/src/Cli/CronJobs/StreamsCronJob.php
+++ b/src/Cli/CronJobs/StreamsCronJob.php
@@ -135,9 +135,9 @@ class StreamsCronJob implements CommandInterface {
         $rMigrate = $rStates !== null && !empty($rStates['accepting']) && StreamProcess::supervisionEnabled();
 
         if ($rRedis) {
-            $db->query('SELECT t2.stream_display_name, t1.stream_started, t1.stream_info, t2.fps_restart, t1.stream_status, t1.progress_info, t1.stream_id, t1.monitor_pid, t1.on_demand, t1.server_stream_id, t1.pid, servers_attached.attached, t2.vframes_server_id, t2.vframes_pid, t2.tv_archive_server_id, t2.tv_archive_pid FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type LEFT JOIN (SELECT `stream_id`, COUNT(*) AS `attached` FROM `streams_servers` WHERE `parent_id` = ? AND `pid` IS NOT NULL AND `pid` > 0 AND `monitor_pid` IS NOT NULL AND `monitor_pid` > 0) AS `servers_attached` ON `servers_attached`.`stream_id` = t1.`stream_id` WHERE (t1.pid IS NOT NULL OR t1.stream_status <> 0 OR t1.to_analyze = 1) AND t1.server_id = ? AND t3.live = 1', SERVER_ID, SERVER_ID);
+            $db->query('SELECT t2.stream_display_name, t2.delay_minutes, t1.stream_started, t1.stream_info, t2.fps_restart, t1.stream_status, t1.progress_info, t1.stream_id, t1.monitor_pid, t1.on_demand, t1.server_stream_id, t1.pid, servers_attached.attached, t2.vframes_server_id, t2.vframes_pid, t2.tv_archive_server_id, t2.tv_archive_pid FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type LEFT JOIN (SELECT `stream_id`, COUNT(*) AS `attached` FROM `streams_servers` WHERE `parent_id` = ? AND `pid` IS NOT NULL AND `pid` > 0 AND `monitor_pid` IS NOT NULL AND `monitor_pid` > 0 GROUP BY `stream_id`) AS `servers_attached` ON `servers_attached`.`stream_id` = t1.`stream_id` WHERE (t1.pid IS NOT NULL OR t1.stream_status <> 0 OR t1.to_analyze = 1) AND t1.server_id = ? AND t3.live = 1', SERVER_ID, SERVER_ID);
         } else {
-            $db->query("SELECT t2.stream_display_name, t1.stream_started, t1.stream_info, t2.fps_restart, t1.stream_status, t1.progress_info, t1.stream_id, t1.monitor_pid, t1.on_demand, t1.server_stream_id, t1.pid, clients.online_clients, clients_hls.online_clients_hls, servers_attached.attached, t2.vframes_server_id, t2.vframes_pid, t2.tv_archive_server_id, t2.tv_archive_pid FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type LEFT JOIN (SELECT stream_id, COUNT(*) as online_clients FROM `lines_live` WHERE `server_id` = ? AND `hls_end` = 0 GROUP BY stream_id) AS clients ON clients.stream_id = t1.stream_id LEFT JOIN (SELECT `stream_id`, COUNT(*) AS `attached` FROM `streams_servers` WHERE `parent_id` = ? AND `pid` IS NOT NULL AND `pid` > 0 AND `monitor_pid` IS NOT NULL AND `monitor_pid` > 0) AS `servers_attached` ON `servers_attached`.`stream_id` = t1.`stream_id` LEFT JOIN (SELECT stream_id, COUNT(*) as online_clients_hls FROM `lines_live` WHERE `server_id` = ? AND `container` = 'hls' AND `hls_end` = 0 GROUP BY stream_id) AS clients_hls ON clients_hls.stream_id = t1.stream_id WHERE (t1.pid IS NOT NULL OR t1.stream_status <> 0 OR t1.to_analyze = 1) AND t1.server_id = ? AND t3.live = 1", SERVER_ID, SERVER_ID, SERVER_ID, SERVER_ID);
+            $db->query("SELECT t2.stream_display_name, t2.delay_minutes, t1.stream_started, t1.stream_info, t2.fps_restart, t1.stream_status, t1.progress_info, t1.stream_id, t1.monitor_pid, t1.on_demand, t1.server_stream_id, t1.pid, clients.online_clients, clients_hls.online_clients_hls, servers_attached.attached, t2.vframes_server_id, t2.vframes_pid, t2.tv_archive_server_id, t2.tv_archive_pid FROM `streams_servers` t1 INNER JOIN `streams` t2 ON t2.id = t1.stream_id AND t2.direct_source = 0 INNER JOIN `streams_types` t3 ON t3.type_id = t2.type LEFT JOIN (SELECT stream_id, COUNT(*) as online_clients FROM `lines_live` WHERE `server_id` = ? AND `hls_end` = 0 GROUP BY stream_id) AS clients ON clients.stream_id = t1.stream_id LEFT JOIN (SELECT `stream_id`, COUNT(*) AS `attached` FROM `streams_servers` WHERE `parent_id` = ? AND `pid` IS NOT NULL AND `pid` > 0 AND `monitor_pid` IS NOT NULL AND `monitor_pid` > 0 GROUP BY `stream_id`) AS `servers_attached` ON `servers_attached`.`stream_id` = t1.`stream_id` LEFT JOIN (SELECT stream_id, COUNT(*) as online_clients_hls FROM `lines_live` WHERE `server_id` = ? AND `container` = 'hls' AND `hls_end` = 0 GROUP BY stream_id) AS clients_hls ON clients_hls.stream_id = t1.stream_id WHERE (t1.pid IS NOT NULL OR t1.stream_status <> 0 OR t1.to_analyze = 1) AND t1.server_id = ? AND t3.live = 1", SERVER_ID, SERVER_ID, SERVER_ID, SERVER_ID);
         }
 
         if ($db->num_rows() > 0) {
@@ -192,6 +192,9 @@ class StreamsCronJob implements CommandInterface {
                         if ($rQueue == 0 && $rAdminQueue == 0 && $rStream['online_clients'] == 0 && (file_exists(STREAMS_PATH . $rStream['stream_id'] . '_.m3u8') || SettingsManager::getInt('on_demand_wait_time') < time() - intval($rStream['stream_started']) || $rStream['stream_status'] == 1)) {
                             echo 'Stop on-demand stream...' . "\n\n";
                             StreamProcess::stopStream($rStream['stream_id'], true);
+                            // Stopped: nothing below applies (it would start a thumbnail
+                            // and a TV archive worker for the stream just stopped).
+                            continue;
                         }
                     }
 
@@ -232,8 +235,17 @@ class StreamsCronJob implements CommandInterface {
                         // stamp so a stream whose ingest keeps failing is not
                         // restart-looped every cron tick. Proxy streams have no
                         // local ffmpeg, so they never reach this running branch.
-                        if (FanoutClient::daemonStreamMissing($rStream['stream_id'])) {
-                            $rRefeedStamp = STREAMS_PATH . $rStream['stream_id'] . '_.refeed';
+                        // Only an ffmpeg producer needs the restart: a broken tee slave
+                        // stays broken. The PHP relays (LLOD, loopback) and a delayed
+                        // stream's DelayCommand re-register and redial the daemon by
+                        // themselves (IngestFeeder), and restarting a delayed stream
+                        // would throw its buffer away.
+                        $rSelfFeeding = intval($rStream['delay_minutes'] ?? 0) > 0 || ProcessManager::producerKind($rPID) === 'php';
+                        if (!$rSelfFeeding && FanoutClient::daemonStreamMissing($rStream['stream_id'])) {
+                            // The stamp lives outside STREAMS_PATH: the restart below
+                            // runs `rm -f <id>_*` there, which deleted a `<id>_.refeed`
+                            // stamp — and with it the 120 s throttle it was meant to be.
+                            $rRefeedStamp = SIGNALS_TMP_PATH . 'refeed_' . intval($rStream['stream_id']);
                             if (!file_exists($rRefeedStamp) || time() - filemtime($rRefeedStamp) > 120) {
                                 echo 'Daemon lost stream ' . $rStream['stream_id'] . ' (restarted) — re-feeding...' . "\n\n";
                                 touch($rRefeedStamp);

--- a/src/Domain/Stream/ConnectionTracker.php
+++ b/src/Domain/Stream/ConnectionTracker.php
@@ -5,6 +5,7 @@ namespace XcVm\Domain\Stream;
 use XcVm\Core\Config\SettingsManager;
 use XcVm\Core\Process\ProcessManager;
 use XcVm\Domain\Server\ServerRepository;
+use XcVm\Streaming\Fanout\FanoutClient;
 
 /**
  * ConnectionTracker — live streaming connection management.
@@ -336,7 +337,10 @@ class ConnectionTracker {
 		if (!$rRedis) {
 			return false;
 		}
-		$rKey = 'SIGNAL#' . md5($rServerID . '#' . $rPID . '#' . $rRTMP);
+		// The payload is part of the key when there is one: pid-less signals
+		// (a daemon viewer's drop_con) would otherwise all share one key per server
+		// and overwrite each other before the target's signals daemon read them.
+		$rKey = 'SIGNAL#' . md5($rServerID . '#' . $rPID . '#' . $rRTMP . (is_null($rCustomData) ? '' : '#' . json_encode($rCustomData)));
 		$rData = array('pid' => $rPID, 'server_id' => $rServerID, 'rtmp' => $rRTMP, 'time' => time(), 'custom_data' => $rCustomData, 'key' => $rKey);
 		return $rRedis->multi()->sAdd('SIGNALS#' . $rServerID, $rKey)->set($rKey, igbinary_serialize($rData))->exec();
 	}
@@ -705,6 +709,10 @@ class ConnectionTracker {
 			return false;
 		}
 		$rMulti = $rRedis->multi();
+		// An HLS uuid is derived from the player (hlsConnectionKey), so a re-auth
+		// after a close reuses it: leave ENDED, or the main server's reaper would
+		// close and delete this fresh connection as the old ended one.
+		$rMulti->sRem('ENDED', $rData['uuid']);
 		$rMulti->zAdd('LINE#' . $rData['identity'], $rData['date_start'], $rData['uuid']);
 		$rMulti->zAdd('LINE_ALL#' . $rData['identity'], $rData['date_start'], $rData['uuid']);
 		$rMulti->zAdd('STREAM#' . $rData['stream_id'], $rData['date_start'], $rData['uuid']);
@@ -771,6 +779,13 @@ class ConnectionTracker {
 
 		$db = self::db();
 
+		// A re-auth after a close reuses the player's HLS uuid. Drop the closed row
+		// (its activity was logged when it was closed) — the reaper deletes by uuid
+		// and would otherwise take this new row down with the old one.
+		if ($rContainer === 'hls') {
+			$db->query('DELETE FROM `lines_live` WHERE `uuid` = ? AND `hls_end` = 1;', $rConn["uuid"]);
+		}
+
 		if (is_null($rCtx["is_hmac"])) {
 			return $db->query('INSERT INTO `lines_live` (`user_id`,`stream_id`,`server_id`,`proxy_id`,`user_agent`,`user_ip`,`container`,`pid`,`uuid`,`date_start`,`geoip_country_code`,`isp`,`external_device`,`hls_last_read`) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)', $rConn["user_id"], $rConn["stream_id"], $rConn["server_id"], $rConn["proxy_id"], $rConn["user_agent"], $rConn["user_ip"], $rConn["container"], $rConn["pid"], $rConn["uuid"], $rConn["date_start"], $rConn["geoip_country_code"], $rConn["isp"], $rConn["external_device"], $rConn["hls_last_read"]);
 		}
@@ -796,7 +811,16 @@ class ConnectionTracker {
 	 */
 	public static function lookupLive(array $rSettings, array $rCtx, string $rContainer, bool $rWithPid, bool $rOpenOnly, bool $rAllowAdaptive): ?array {
 		if ($rSettings["redis_handler"]) {
-			return self::getConnection($rCtx["uuid"]);
+			$rConnection = self::getConnection($rCtx["uuid"]);
+			// Same meaning as `hls_end = 0` on the table path: a connection that was
+			// closed — kicked for the line's limit, or by an admin — is not resumed
+			// by the player's next playlist request (which would quietly undo the
+			// kick); the request is treated as a new connection and its token's
+			// expiry and the line's limits apply again.
+			if ($rOpenOnly && is_array($rConnection) && !empty($rConnection['hls_end'])) {
+				return null;
+			}
+			return $rConnection;
 		}
 
 		$db = self::db();
@@ -912,6 +936,35 @@ class ConnectionTracker {
 	}
 
 	/**
+	 * End a daemon-served live-TS viewer — a `pid = 0` row (ADR 0003). The worker
+	 * that admitted it returned at the X-Accel hand-off, so there is no process to
+	 * kill: the xc_fanout daemon serving it has to drop the uuid. On this node that
+	 * is one control call; for a viewer on another node it is a `drop_con` signal,
+	 * which that node's signals daemon turns into the same call.
+	 *
+	 * @param array $rConnection Connection row (needs uuid and server_id).
+	 * @return void
+	 */
+	public static function dropDaemonViewer(array $rConnection): void {
+		global $rSettings;
+		$rUUID = (string) ($rConnection['uuid'] ?? '');
+		if ($rUUID === '') {
+			return;
+		}
+		$rServerID = intval($rConnection['server_id'] ?? 0);
+		if ($rServerID <= 0 || $rServerID == SERVER_ID) {
+			FanoutClient::dropConnection($rUUID);
+			return;
+		}
+		$rSignal = array('type' => 'drop_con', 'uuid' => $rUUID);
+		if (!empty($rSettings['redis_handler'])) {
+			self::redisSignal(0, $rServerID, 0, $rSignal);
+		} else {
+			self::db()->query('INSERT INTO `signals` (`server_id`, `cache`, `time`, `custom_data`) VALUES(?, 1, UNIX_TIMESTAMP(), ?);', $rServerID, json_encode($rSignal));
+		}
+	}
+
+	/**
 	 * Close an active connection.
 	 *
 	 * Performs the full close cycle: kills the process (RTMP drop client,
@@ -973,7 +1026,9 @@ class ConnectionTracker {
 							@unlink(CONS_TMP_PATH . $rActivityInfo['stream_id'] . '/' . $rActivityInfo['uuid']);
 						}
 					} else {
-						if ($rActivityInfo['server_id'] == SERVER_ID) {
+						if (intval($rActivityInfo['pid']) === 0) {
+							self::dropDaemonViewer($rActivityInfo);
+						} elseif ($rActivityInfo['server_id'] == SERVER_ID) {
 							if (!($rActivityInfo['pid'] != getmypid() && is_numeric($rActivityInfo['pid']) && 0 < $rActivityInfo['pid'])) {
 							} else {
 								posix_kill(intval($rActivityInfo['pid']), 9);

--- a/src/Domain/Stream/StreamProcess.php
+++ b/src/Domain/Stream/StreamProcess.php
@@ -8,6 +8,7 @@ use XcVm\Core\Http\CurlClient;
 use XcVm\Core\Process\ProcessManager;
 use XcVm\Core\Util\StreamUtils;
 use XcVm\Streaming\Fanout\FanoutClient;
+use XcVm\Streaming\Fanout\IngestFeeder;
 
 /**
  * StreamProcess — stream process
@@ -289,12 +290,14 @@ class StreamProcess {
 		if (!empty($rSubtitles) && !empty($rSubtitles['files']) && is_array($rSubtitles['files'])) {
 			$rCount = count($rSubtitles['files']);
 			for ($i = 0; $i < $rCount; $i++) {
-				$rSubtitleFile = escapeshellarg($rSubtitles['files'][$i]);
 				$rInputCharset = escapeshellarg($rSubtitles['charset'][$i]);
 				if ($rSubtitles['location'] == SERVER_ID) {
-					$rSubtitlesImport .= '-sub_charenc ' . $rInputCharset . ' -i ' . $rSubtitleFile . ' ';
+					$rSubtitlesImport .= '-sub_charenc ' . $rInputCharset . ' -i ' . escapeshellarg($rSubtitles['files'][$i]) . ' ';
 				} else {
-					$rSubtitlesImport .= '-sub_charenc ' . $rInputCharset . ' -i "' . $rServers[$rSubtitles['location']]['api_url'] . '&action=getFile&filename=' . urlencode($rSubtitleFile) . '" ';
+					// URL-encode the raw path, then quote the whole URL for the shell.
+					// (Encoding the already shell-quoted path sent the quotes along,
+					// so the remote server looked up a filename that does not exist.)
+					$rSubtitlesImport .= '-sub_charenc ' . $rInputCharset . ' -i ' . escapeshellarg($rServers[$rSubtitles['location']]['api_url'] . '&action=getFile&filename=' . urlencode($rSubtitles['files'][$i])) . ' ';
 				}
 			}
 			for ($i = 0; $i < $rCount; $i++) {
@@ -465,6 +468,31 @@ class StreamProcess {
 		$rDaemon = '[f=mpegts:onfail=ignore:mpegts_flags=+initial_discontinuity]unix:' . $rIngestSock;
 
 		return $rOptions . ' -f tee "' . $rHls . '|' . $rDaemon . '"';
+	}
+
+	/**
+	 * The output options a live-on-demand (LLOD) start adds for low latency.
+	 *
+	 * The encoder tune is chosen per encoder: `-tune zerolatency` is an x264/x265
+	 * option, which NVENC rejects as an unknown tune value (failing the start) and
+	 * a stream copy ignores; NVENC's equivalent is `-zerolatency 1`.
+	 *
+	 * @param array $rTranscodeAttributes Resolved transcode attributes.
+	 * @return string Options for the {LLOD} placeholder.
+	 */
+	private static function llodOutputOptions(array $rTranscodeAttributes): string {
+		$rCodec = $rTranscodeAttributes['-vcodec'] ?? 'copy';
+		if (is_array($rCodec)) {
+			$rCodec = $rCodec['cmd'] ?? ($rCodec['val'] ?? '');
+		}
+		$rCodec = strtolower(trim((string) $rCodec));
+		$rTune = '';
+		if (in_array($rCodec, array('libx264', 'libx265'), true)) {
+			$rTune = '-tune zerolatency ';
+		} elseif (substr($rCodec, -6) === '_nvenc') {
+			$rTune = '-zerolatency 1 ';
+		}
+		return $rTune . '-strict experimental';
 	}
 
 	/**
@@ -783,9 +811,12 @@ class StreamProcess {
 		$rReconnect = (!$rLoopback && is_string($rSource) && preg_match('#^https?://#i', $rSource))
 			? '-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 '
 			: '';
-		// +discardcorrupt tolerates corrupt packets from the source; keep it scoped
-		// to the on-demand (LLOD) path where it originally shipped.
-		$rLLODInputFlags = $rReconnect . (($rLLOD && !$rLoopback) ? '-fflags +discardcorrupt ' : '');
+		// LLOD input flags: +discardcorrupt tolerates corrupt packets from the
+		// source, +nobuffer stops the demuxer holding back what it read during
+		// stream analysis. Both are demuxer (input) flags — +nobuffer used to sit
+		// among the output options, where it does nothing. Scoped to the on-demand
+		// (LLOD) path where they shipped.
+		$rLLODInputFlags = $rReconnect . (($rLLOD && !$rLoopback) ? '-fflags +discardcorrupt+nobuffer ' : '');
 
 		// Command-template defaults: only the non-custom_ffmpeg branch below
 		// assigns these, yet the {MAP}/{GEN_PTS}/{READ_NATIVE} substitution and
@@ -856,7 +887,7 @@ class StreamProcess {
 			$rFFMPEG = ((stripos($rStream['stream_info']['custom_ffmpeg'], 'nvenc') !== false ? $rFFMPEG_GPU : $rFFMPEG_CPU)) . ' -y -nostdin -hide_banner -loglevel ' . (($rSettings['ffmpeg_warnings'] ? 'warning' : 'error')) . ' -progress "' . $rProgressFile . '" ' . $rStream['stream_info']['custom_ffmpeg'];
 		}
 
-		$rLLODOptions = ($rLLOD && !$rLoopback ? '-tune zerolatency -fflags nobuffer -flags low_delay -strict experimental -threads 0' : '');
+		$rLLODOptions = ($rLLOD && !$rLoopback ? self::llodOutputOptions($rStream['stream_info']['transcode_attributes']) : '');
 		$rOutputs = array();
 
 		if ($rLoopback) {
@@ -874,11 +905,11 @@ class StreamProcess {
 		$rInitTime = min(2, intval($rSegmentSettings['seg_time']));
 		// When the xc_fanout daemon accepted an ingest registration (reachable),
 		// tee the HLS output to it too (ADR 0003, A2). Never for delay, whose HLS
-		// goes to its own directory. startStream() registers no ingest for a
-		// loopback stream (the PHP relay feeds the daemon for those); a supervised
-		// one does, because the supervisor confirms and judges a stream by the
-		// bytes the daemon receives. If the daemon was unreachable
-		// ($data['ingestSock'] is null) the original on-disk-only HLS runs.
+		// goes to its own directory and whose DelayCommand feeds the daemon the
+		// delayed segments. A loopback stream tees too: clients are served only by
+		// the daemon, so an ffmpeg loopback that did not feed it could not be
+		// watched. If the daemon was unreachable ($data['ingestSock'] is null) the
+		// on-disk-only HLS runs.
 		if (!$rDelayActive && !empty($data['ingestSock'])) {
 			// The tee muxer needs an EXPLICIT -map — plain single outputs use
 			// ffmpeg's automatic stream selection, but tee does not ("Output file
@@ -1227,11 +1258,10 @@ class StreamProcess {
 		list($rProbesize, $rAnalyseDuration, $rTimeout) = self::resolveProbeSettings($rStream['server_info']['on_demand'], $rInfo['probesize_ondemand'], $rLLOD, $rSettings);
 
 		self::writeStreamKeyIv($rStreamID);
-		$rEncKey = $rEncIV = null;
-		if (!empty($rSettings['encrypt_hls']) && !$rLoopback) {
-			$rEncKey = @bin2hex((string) @file_get_contents(STREAMS_PATH . $rStreamID . '_.key'));
-			$rEncIV = @bin2hex((string) @file_get_contents(STREAMS_PATH . $rStreamID . '_.iv'));
-		}
+		// Loopback included: the playlist declares AES-128 whenever encrypt_hls is
+		// on (HLSGenerator::tokenizeDaemonPlaylist), so a daemon fed without the
+		// key served plain segments no player could decrypt.
+		[$rEncKey, $rEncIV] = !empty($rSettings['encrypt_hls']) ? IngestFeeder::streamKey($rStreamID) : array(null, null);
 		$rIngestSock = FanoutClient::registerIngest($rStreamID, $rEncKey, $rEncIV);
 		if ($rIngestSock === null) {
 			return null; // no daemon to feed: the stream runs the legacy way
@@ -1968,11 +1998,13 @@ class StreamProcess {
 			if ($db->num_rows() > 0) {
 				$rStream['server_info'] = $db->get_row();
 				if ($rStream['server_info']['parent_id'] != 0) {
+					// The key first: the relay hands it to the daemon when it
+					// registers its ingest, moments after it starts.
+					self::writeStreamKeyIv($rStreamID);
 					shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php loopback ' . intval($rStreamID) . ' ' . intval($rStream['server_info']['parent_id']) . ' >/dev/null 2>/dev/null & echo $! > ' . STREAMS_PATH . intval($rStreamID) . '_.pid');
 					$rPID = intval(file_get_contents(STREAMS_PATH . $rStreamID . '_.pid'));
 					$rLoopURL = (!is_null($rServers[SERVER_ID]['private_url_ip']) && !is_null($rServers[$rStream['server_info']['parent_id']]['private_url_ip']) ? $rServers[$rStream['server_info']['parent_id']]['private_url_ip'] : $rServers[$rStream['server_info']['parent_id']]['public_url_ip']);
 					$rCurrentSource = $rLoopURL . 'admin/live?stream=' . intval($rStreamID) . '&password=' . urlencode($rSettings['live_streaming_pass']) . '&extension=ts';
-					self::writeStreamKeyIv($rStreamID);
 					$db->query('UPDATE `streams_servers` SET `delay_available_at` = ?,`to_analyze` = 0,`stream_started` = ?,`stream_info` = ?,`stream_status` = 2,`pid` = ?,`progress_info` = ?,`current_source` = ? WHERE `stream_id` = ? AND `server_id` = ?', null, time(), null, $rPID, json_encode(array()), $rCurrentSource, $rStreamID, SERVER_ID);
 					self::updateStream($rStreamID);
 					return array('main_pid' => $rPID, 'stream_source' => $rLoopURL . 'admin/live?stream=' . intval($rStreamID) . '&password=' . urlencode($rSettings['live_streaming_pass']) . '&extension=ts', 'delay_enabled' => false, 'parent_id' => 0, 'delay_start_at' => null, 'playlist' => STREAMS_PATH . $rStreamID . '_.m3u8', 'transcode' => false, 'offset' => 0);
@@ -2001,9 +2033,11 @@ class StreamProcess {
 		foreach ($rStreamArguments as $rStreamArgument) {
 			$rArgumentMap[$rStreamArgument['argument_key']] = array('value' => $rStreamArgument['value'], 'argument_default_value' => $rStreamArgument['argument_default_value']);
 		}
+		// The key first: the segmenter hands it to the daemon when it registers
+		// its ingest, moments after it starts.
+		self::writeStreamKeyIv($rStreamID);
 		shell_exec(PHP_BIN . ' ' . MAIN_HOME . 'console.php llod ' . intval($rStreamID) . ' "' . base64_encode(json_encode($rSources)) . '" "' . base64_encode(json_encode($rArgumentMap)) . '" >/dev/null 2>/dev/null & echo $! > ' . STREAMS_PATH . intval($rStreamID) . '_.pid');
 		$rPID = intval(file_get_contents(STREAMS_PATH . $rStreamID . '_.pid'));
-		self::writeStreamKeyIv($rStreamID);
 		$db->query('UPDATE `streams_servers` SET `delay_available_at` = ?,`to_analyze` = 0,`stream_started` = ?,`stream_info` = ?,`stream_status` = 2,`pid` = ?,`progress_info` = ?,`current_source` = ? WHERE `stream_id` = ? AND `server_id` = ?', null, time(), null, $rPID, json_encode(array()), $rSources[0], $rStreamID, SERVER_ID);
 		self::updateStream($rStreamID);
 		return array('main_pid' => $rPID, 'stream_source' => $rSources[0], 'delay_enabled' => false, 'parent_id' => 0, 'delay_start_at' => null, 'playlist' => STREAMS_PATH . $rStreamID . '_.m3u8', 'transcode' => false, 'offset' => 0);
@@ -2208,6 +2242,10 @@ class StreamProcess {
 
 							break;
 						}
+					} else {
+						// LLOD skips the probe, so nothing above can pick a source:
+						// start on the first one rather than falling through to the last.
+						break;
 					}
 				}
 				if (!($rStream['server_info']['on_demand'] && $rLLOD)) {
@@ -2257,21 +2295,20 @@ class StreamProcess {
 					// Assemble the live ffmpeg command (pure). buildLive() does all the
 					// transcode-attribute resolution and {TEMPLATE} substitution internally, so
 					// it is fed the raw stream row.
-					// Register a daemon ingest for standard live streams (ADR 0003,
-					// A2). The daemon starts listening on the returned socket, then
-					// buildLive tees the HLS output into it. Null when the daemon is
-					// unreachable → buildLive emits the on-disk-only HLS (rollback).
-					// Generate the stream's HLS key/iv up-front so, when encrypt_hls
-					// is on, we can hand them to the daemon at ingest registration
-					// and it encrypts the HLS segments it serves (ADR 0003, Phase B
-					// encrypted) — matching the panel's #EXT-X-KEY.
+					// Register a daemon ingest (ADR 0003, A2). The daemon starts
+					// listening on the returned socket, then buildLive tees the HLS
+					// output into it. Null when the daemon is unreachable →
+					// buildLive emits the on-disk-only HLS. Loopback streams tee too
+					// (clients are served only by the daemon); a delayed stream does
+					// not — its encoder output is the undelayed one, and DelayCommand
+					// feeds the daemon the delayed segments instead.
+					// The stream's HLS key/iv are generated up-front so, when
+					// encrypt_hls is on, the daemon gets them at registration and
+					// encrypts the HLS segments it serves (ADR 0003, Phase B) —
+					// matching the panel's #EXT-X-KEY.
 					self::writeStreamKeyIv($rStreamID);
-					$rEncKey = $rEncIV = null;
-					if (!empty($rSettings['encrypt_hls']) && !$rLoopback && !$rDelayActive) {
-						$rEncKey = @bin2hex((string) @file_get_contents(STREAMS_PATH . $rStreamID . '_.key'));
-						$rEncIV = @bin2hex((string) @file_get_contents(STREAMS_PATH . $rStreamID . '_.iv'));
-					}
-					$rIngestSock = (!$rLoopback && !$rDelayActive) ? FanoutClient::registerIngest($rStreamID, $rEncKey, $rEncIV) : null;
+					[$rEncKey, $rEncIV] = (!empty($rSettings['encrypt_hls']) && !$rDelayActive) ? IngestFeeder::streamKey(intval($rStreamID)) : array(null, null);
+					$rIngestSock = !$rDelayActive ? FanoutClient::registerIngest(intval($rStreamID), $rEncKey, $rEncIV) : null;
 
 					$rFFMPEG = self::buildLive(array(
 						'stream' => $rStream, 'settings' => $rSettings, 'servers' => $rServers,

--- a/src/Public/stream/auth.php
+++ b/src/Public/stream/auth.php
@@ -139,13 +139,17 @@ if ($rExtension) {
 		$rStream = (igbinary_unserialize(file_get_contents(STREAMS_TMP_PATH . 'stream_' . $rStreamID)) ?: null);
 		$rAvailableServers = array();
 
-		if ($rType == 'archive') {
+		// Catch-up is served from the archive server, whether or not the channel
+		// is live anywhere right now. (This compared against 'archive', a type the
+		// requests never carry, so timeshift fell through to the live check and a
+		// channel whose live stream was down refused its own catch-up.)
+		if ($rType == 'timeshift') {
 			if ((0 < $rStream['info']['tv_archive_duration'] && 0 < $rStream['info']['tv_archive_server_id'] && array_key_exists($rStream['info']['tv_archive_server_id'], $rServers) && $rServers[$rStream['info']['tv_archive_server_id']]['server_online'])) {
-				$rAvailableServers[] = array($rStream['info']['tv_archive_server_id']);
+				$rAvailableServers[] = $rStream['info']['tv_archive_server_id'];
 			}
 		} else {
 			if (($rStream['info']['direct_source'] == 1 && $rStream['info']['direct_proxy'] == 0)) {
-				$rAvailableServers[] = $rServerID;
+				$rAvailableServers[] = 'direct'; // redirected straight to the source (SERVER_ID is not defined yet here)
 			}
 
 			$servers = $rStream['servers'] ?? [];
@@ -170,7 +174,10 @@ if ($rExtension) {
 		}
 
 		if (count($rAvailableServers) == 0) {
-			OffAirHandler::showVideoServer('show_not_on_air_video', 'not_on_air_video_path', $rExtension, $rUserInfo, $rIP, $rCountryCode, $rUserInfo['con_isp_name'], defined('SERVER_ID') ? SERVER_ID : 0);
+			// This fast path only runs with show_not_on_air_video off, where the
+			// off-air handler can only answer STREAM_OFFLINE — and the line is not
+			// authenticated yet, so there is no user info to hand it.
+			generateError('STREAM_OFFLINE');
 		}
 	}
 
@@ -196,7 +203,7 @@ if ($rExtension) {
 	$rIsHMAC = null;
 	$rIdentifier = '';
 	$rPID = getmypid();
-	$rUUID = md5(uniqid());
+	$rUUID = bin2hex(random_bytes(16)); // connection id: unpredictable, 32 hex chars like md5()
 	$rIP = $_SERVER['REMOTE_ADDR'];
 	$rCountryCode = GeoIPService::getIPInfo($rIP);
 	$rCountryCode = (empty($rCountryCode) ? "" : $rCountryCode['country']['iso_code']);
@@ -254,7 +261,20 @@ if ($rExtension) {
 		BruteforceGuard::checkAuthFlood($rUserInfo, $rIP);
 		$rUserID = $rUserInfo['id'] ?? null;
 
-		if ((($rServers[SERVER_ID]['enable_proxy'] ?? 0) && !($rProxies[$_SERVER['HTTP_X_IP']] ?? null) && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
+		// A server behind proxies only accepts requests that came through one. The
+		// peer is the TCP connection nginx saw (XC_PEER_ADDR = $realip_remote_addr,
+		// before real_ip rewrote REMOTE_ADDR to the client). The X-IP request header
+		// this used to trust alone is set by whoever sends the request, so a direct
+		// client could name a (public) proxy IP and pass; it now counts only when the
+		// peer is itself an XC_VM server or whitelisted address (a proxy reaching us
+		// from an address other than the one it is registered under), or on an nginx
+		// config too old to pass the peer at all.
+		$rPeerAddr = $_SERVER['XC_PEER_ADDR'] ?? null;
+		$rProxyHeader = $_SERVER['HTTP_X_IP'] ?? '';
+		$rViaProxy = ($rPeerAddr === null)
+			? isset($rProxies[$rProxyHeader])
+			: (isset($rProxies[$rPeerAddr]) || (in_array($rPeerAddr, $rAllowedIPs, true) && isset($rProxies[$rProxyHeader])));
+		if ((($rServers[SERVER_ID]['enable_proxy'] ?? 0) && !$rViaProxy && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
 			generateError('PROXY_ACCESS_DENIED');
 		}
 
@@ -477,7 +497,7 @@ if ($rExtension) {
 							generateError('HLS_DISABLED');
 						}
 
-						$rAdaptive = json_decode($rChannelInfo['adaptive_link'], true);
+						$rAdaptive = json_decode((string) ($rChannelInfo['adaptive_link'] ?? ''), true);
 
 						if (!$rIsHMAC && is_array($rAdaptive) && 0 < count($rAdaptive)) {
 							$rParts = array();
@@ -485,12 +505,15 @@ if ($rExtension) {
 							foreach (array_merge(array($rStreamID), $rAdaptive) as $rAdaptiveID) {
 								if ($rAdaptiveID != $rStreamID) {
 									$rAdaptiveInfo = StreamRedirector::redirectStream($rCached, $rSettings, $rServers, $rAdaptiveID, $rExtension, $rUserInfo, $rCountryCode, $rUserInfo['con_isp_name'], 'live');
+									if (!is_array($rAdaptiveInfo) || empty($rAdaptiveInfo['redirect_id'])) {
+										continue; // a variant with no server to serve it is left out of the master
+									}
 
 									if (($rServers[$rAdaptiveInfo['redirect_id']]['enable_proxy'] && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
 										$rProxies = ConnectionTracker::getProxies($rAdaptiveInfo['redirect_id']);
-											$rProxyID = ProxySelector::availableProxy(array_keys($rProxies), $rCountryCode, $rUserInfo['con_isp_name']);
+										$rProxyID = ProxySelector::availableProxy(array_keys($rProxies), $rCountryCode, $rUserInfo['con_isp_name']);
 										if (!$rProxyID) {
-											generateError('NO_SERVERS_AVAILABLE');
+											continue;
 										}
 
 										$rAdaptiveInfo['originator_id'] = $rAdaptiveInfo['redirect_id'];
@@ -502,13 +525,13 @@ if ($rExtension) {
 									$rAdaptiveInfo = $rChannelInfo;
 								}
 
-								$rStreamInfo = json_decode($rAdaptiveInfo['stream_info'], true);
-								$rBitrate = ($rStreamInfo['bitrate'] ?: 0);
-								$rWidth = ($rStreamInfo['codecs']['video']['width'] ?: 0);
-								$rHeight = ($rStreamInfo['codecs']['video']['height'] ?: 0);
+								$rStreamInfo = json_decode((string) ($rAdaptiveInfo['stream_info'] ?? ''), true);
+								$rBitrate = intval($rStreamInfo['bitrate'] ?? 0);
+								$rWidth = intval($rStreamInfo['codecs']['video']['width'] ?? 0);
+								$rHeight = intval($rStreamInfo['codecs']['video']['height'] ?? 0);
 
 								if ((0 < $rBitrate && 0 < $rHeight && 0 < $rWidth)) {
-									$rTokenData = array('stream_id' => $rAdaptiveID, 'username' => $rUserInfo['username'], 'password' => $rUserInfo['password'], 'extension' => $rExtension, 'pid' => $rPID, 'channel_info' => array('redirect_id' => $rAdaptiveInfo['redirect_id'], 'originator_id' => ($rAdaptiveInfo['originator_id'] ?? null), 'pid' => $rAdaptiveInfo['pid'], 'on_demand' => $rAdaptiveInfo['on_demand'], 'monitor_pid' => $rAdaptiveInfo['monitor_pid']), 'user_info' => array('id' => $rUserInfo['id'], 'max_connections' => $rUserInfo['max_connections'], 'pair_id' => $rUserInfo['pair_id'], 'con_isp_name' => $rUserInfo['con_isp_name'], 'is_restreamer' => $rUserInfo['is_restreamer']), 'external_device' => $rExternalDevice, 'activity_start' => $rActivityStart, 'country_code' => $rCountryCode, 'video_codec' => ($rStreamInfo['codecs']['video']['codec_name'] ?: 'h264'), 'uuid' => $rUUID, 'adaptive' => array($rChannelInfo['redirect_id'], $rStreamID));
+									$rTokenData = array('stream_id' => $rAdaptiveID, 'username' => $rUserInfo['username'], 'password' => $rUserInfo['password'], 'extension' => $rExtension, 'pid' => $rPID, 'channel_info' => array('redirect_id' => $rAdaptiveInfo['redirect_id'], 'originator_id' => ($rAdaptiveInfo['originator_id'] ?? null), 'pid' => $rAdaptiveInfo['pid'], 'on_demand' => $rAdaptiveInfo['on_demand'], 'monitor_pid' => $rAdaptiveInfo['monitor_pid']), 'user_info' => array('id' => $rUserInfo['id'], 'max_connections' => $rUserInfo['max_connections'], 'pair_id' => $rUserInfo['pair_id'], 'con_isp_name' => $rUserInfo['con_isp_name'], 'is_restreamer' => $rUserInfo['is_restreamer']), 'external_device' => $rExternalDevice, 'activity_start' => $rActivityStart, 'country_code' => $rCountryCode, 'video_codec' => ($rStreamInfo['codecs']['video']['codec_name'] ?? 'h264'), 'uuid' => $rUUID, 'adaptive' => array($rChannelInfo['redirect_id'], $rStreamID));
 									$rStreamURL = (string) $rURL . '/auth/' . Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 									$rParts[$rBitrate] = '#EXT-X-STREAM-INF:BANDWIDTH=' . $rBitrate . ',RESOLUTION=' . $rWidth . 'x' . $rHeight . "\n" . $rStreamURL;
 								}
@@ -636,11 +659,18 @@ if ($rExtension) {
 				break;
 			}
 
-			if (($rServers[$rChannelInfo['redirect_id']]['enable_proxy'] && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
-				$rProxies = ConnectionTracker::getProxies($rChannelInfo['redirect_id']);
+			// The archive server's proxies, as for live. (This read $rChannelInfo,
+			// which the timeshift path never sets, so catch-up always bypassed the
+			// proxy — and was refused by an archive server that requires one.)
+			if ((($rServers[$rRedirectID]['enable_proxy'] ?? 0) && (!$rUserInfo['is_restreamer'] || !$rSettings['restreamer_bypass_proxy']))) {
+				$rProxies = ConnectionTracker::getProxies($rRedirectID);
 				$rProxyID = ProxySelector::availableProxy(array_keys($rProxies), $rCountryCode, $rUserInfo['con_isp_name']);
 
-				$rOriginatorID = $rChannelInfo['redirect_id'];
+				if (!$rProxyID) {
+					generateError('NO_SERVERS_AVAILABLE');
+				}
+
+				$rOriginatorID = $rRedirectID;
 				$rRedirectID = $rProxyID;
 			}
 
@@ -745,8 +775,8 @@ if ($rExtension) {
 					$rChannelInfo['redirect_id'] = $rProxyID;
 				}
 
-				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?: null), $rForceHTTP, $rUserID);
-				$rTokenData = array('stream_id' => $rStreamID, 'sub_id' => (intval($rRequest['sid']) ?: 0), 'webvtt' => (intval($rRequest['webvtt']) ?: 0), 'expires' => time() + 5);
+				$rURL = StreamRedirector::getStreamingURL($rSettings, $rServers, $rChannelInfo['redirect_id'], ($rChannelInfo['originator_id'] ?? null), $rForceHTTP, $rUserID);
+				$rTokenData = array('stream_id' => $rStreamID, 'sub_id' => intval($rRequest['sid'] ?? 0), 'webvtt' => intval($rRequest['webvtt'] ?? 0), 'expires' => time() + 5);
 				$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 				header('Location: ' . $rURL . '/subauth/' . $rToken);
 

--- a/src/Public/stream/live.php
+++ b/src/Public/stream/live.php
@@ -61,6 +61,7 @@ if (isset($rRequest["token"])) {
         }
 
         $rStreamID = intval($rTokenData["stream_id"]);
+        OffAirHandler::forStream($rStreamID);
         $rExtension = $rTokenData["extension"];
         $rChannelInfo = $rTokenData["channel_info"];
         $rUserInfo = $rTokenData["user_info"];
@@ -157,6 +158,14 @@ if ($rChannelInfo) {
                     generateError("TOKEN_EXPIRED");
                 }
 
+                // Both pids are dead (checked above), so their files are leftovers
+                // of the last run — e.g. a monitor that gave up under
+                // on_demand_failure_exit. Clear them, or the waits below would read
+                // them back as the new monitor/producer before it wrote its own.
+                @unlink(STREAMS_PATH . $rStreamID . "_.monitor");
+                @unlink(STREAMS_PATH . $rStreamID . "_.pid");
+                AsyncFileOperations::clearFileCache();
+
                 DatabaseFactory::connect(); // the hand-over reads the stream's config
                 if (StreamProcess::startMonitor($rStreamID) === StreamProcess::MONITOR_FANOUT) {
                     // The daemon is the monitor: there is no _.monitor file to wait
@@ -174,10 +183,13 @@ if ($rChannelInfo) {
                 OffAirHandler::showNotOnAir($rExtension, $rUserInfo, $rIP, $rCountryCode, $rServerID, $rProxyID);
             }
 
-            for ($rRetries = 0; !AsyncFileOperations::awaitFileExists(STREAMS_PATH . intval($rStreamID) . "_.pid", 1, 10) && $rRetries < 300; $rRetries++) {
-                AsyncFileOperations::efficientSleep(10000);
-            }
-            $rChannelInfo["pid"] = (intval(AsyncFileOperations::readFile(STREAMS_PATH . $rStreamID . "_.pid")) ?: NULL);
+            // The producer's pid appears once the monitor has probed the source and
+            // launched it, which can take most of the on-demand wait on its own (a
+            // 10 s analyze window for a non-LLOD start) — so the wait is the
+            // configured on_demand_wait_time, not a fixed ~6 s.
+            $rPidWaitMs = max(1, intval($rSettings["on_demand_wait_time"])) * 1000;
+            AsyncFileOperations::awaitFileExists(STREAMS_PATH . intval($rStreamID) . "_.pid", intdiv($rPidWaitMs, 20), 20);
+            $rChannelInfo["pid"] = (intval(AsyncFileOperations::readFile(STREAMS_PATH . $rStreamID . "_.pid", false)) ?: NULL);
 
             if (!$rChannelInfo["pid"]) {
                 OffAirHandler::showNotOnAir($rExtension, $rUserInfo, $rIP, $rCountryCode, $rServerID, $rProxyID);
@@ -215,7 +227,7 @@ if ($rChannelInfo) {
             }
         } else {
             $maxRetries = intval($rSettings["on_demand_wait_time"]) * 10;
-            $foundFile = AsyncFileOperations::awaitAnyFileExists([$rPlaylist, STREAMS_PATH . $rStreamID . "_.m3u8"], $maxRetries, 100);
+            $foundFile = AsyncFileOperations::awaitAnyFileExists([$rPlaylist], $maxRetries, 100);
 
             if (!$foundFile) {
                 generateError("WAIT_TIME_EXPIRED");
@@ -249,7 +261,9 @@ if ($rChannelInfo) {
                 $rAcceptIP = $rConnections[0]["user_ip"];
             }
         } else {
-            $db->query('SELECT `user_ip` FROM `lines_live` WHERE `user_id` = ? AND `hls_end` = 0 ORDER BY `activity_id` DESC LIMIT 1;', $rUserInfo["id"]);
+            // The FIRST connection's IP is the accepted one — as the Redis path
+            // above picks it (oldest date_start); this used to take the newest.
+            $db->query('SELECT `user_ip` FROM `lines_live` WHERE `user_id` = ? AND `hls_end` = 0 ORDER BY `activity_id` ASC LIMIT 1;', $rUserInfo["id"]);
 
             if ($db->num_rows() == 1) {
                 $rAcceptIP = $db->get_row()["user_ip"];
@@ -321,7 +335,7 @@ if ($rChannelInfo) {
                 generateError("LINE_CREATE_FAIL");
             }
 
-            StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent);
+            StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent, $rTokenData["uuid"]);
 
             if ($rSettings["redis_handler"]) {
                 RedisManager::closeInstance();
@@ -345,7 +359,9 @@ if ($rChannelInfo) {
 
             if ($rHLS) {
                 touch(CONS_TMP_PATH . $rTokenData["uuid"]);
-                ob_end_clean();
+                while (ob_get_level()) {
+                    ob_end_clean();
+                }
                 header("Content-Type: application/x-mpegurl");
                 header("Content-Length: " . strlen($rHLS));
                 header("Cache-Control: no-store, no-cache, must-revalidate");
@@ -397,7 +413,7 @@ if ($rChannelInfo) {
                 generateError("LINE_CREATE_FAIL");
             }
 
-            StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent);
+            StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent, $rTokenData["uuid"]);
 
             if ($rSettings["redis_handler"]) {
                 RedisManager::closeInstance();

--- a/src/Public/stream/timeshift.php
+++ b/src/Public/stream/timeshift.php
@@ -10,6 +10,7 @@ use XcVm\Infrastructure\Redis\RedisManager;
 use XcVm\Streaming\AsyncFileOperations;
 use XcVm\Streaming\Auth\StreamAuth;
 use XcVm\Streaming\Auth\StreamAuthMiddleware;
+use XcVm\Streaming\Delivery\HttpRange;
 use XcVm\Streaming\Lifecycle\ShutdownHandler;
 
 /**
@@ -135,6 +136,8 @@ if ($rUserInfo) {
 		DatabaseFactory::connect();
 	}
 
+	$rConnection = null;
+
 	switch ($rExtension) {
 		case 'm3u8':
 			if ($rSettings['redis_handler']) {
@@ -188,7 +191,7 @@ if ($rUserInfo) {
 				generateError('LINE_CREATE_FAIL');
 			}
 
-			StreamAuth::validateConnections($rUserInfo, null, null, $rIP, $rUserAgent);
+			StreamAuth::validateConnections($rUserInfo, null, null, $rIP, $rUserAgent, $rTokenData['uuid']);
 
 			if ($rSettings['redis_handler']) {
 				RedisManager::closeInstance();
@@ -285,7 +288,7 @@ if ($rUserInfo) {
 				generateError('LINE_CREATE_FAIL');
 			}
 
-			StreamAuth::validateConnections($rUserInfo, null, null, $rIP, $rUserAgent);
+			StreamAuth::validateConnections($rUserInfo, null, null, $rIP, $rUserAgent, $rTokenData['uuid']);
 
 			if ($rSettings['redis_handler']) {
 				RedisManager::closeInstance();
@@ -307,64 +310,17 @@ if ($rUserInfo) {
 			touch(CONS_TMP_PATH . $rTokenData['uuid']);
 			header('Content-Type: video/mp2t');
 			$rConSpeedFile = DIVERGENCE_TMP_PATH . $rTokenData['uuid'];
-			$rLength = $rSize = getLength($rQueue) - $rOffset;
+			// The response is the queued minute files back to back, the first one
+			// from its .offset (a partial first minute).
+			$rSize = getLength($rQueue) - $rOffset;
 			$rBitrate = ($rSize * 0.008) / ($rDuration * 60);
-			header('Accept-Ranges: 0-' . $rLength);
-			$rStart = 0;
-			$rEnd = $rSize - 1;
-
-			if (empty($_SERVER['HTTP_RANGE'])) {
-			} else {
-				$rRangeStart = $rStart;
-				$rRangeEnd = $rEnd;
-				list(, $rRange) = explode('=', $_SERVER['HTTP_RANGE'], 2);
-
-				if (strpos($rRange, ',') === false) {
-
-
-
-
-					if ($rRange == '-') {
-						$rRangeStart = $rSize - substr($rRange, 1);
-					} else {
-						$rRange = explode('-', $rRange);
-						$rRangeStart = $rRange[0];
-						$rRangeEnd = (isset($rRange[1]) && is_numeric($rRange[1]) ? $rRange[1] : $rSize);
-					}
-
-					$rRangeEnd = ($rEnd < $rRangeEnd ? $rEnd : $rRangeEnd);
-
-					if (!($rRangeEnd < $rRangeStart || $rSize - 1 < $rRangeStart || $rSize <= $rRangeEnd)) {
-						$rStart = $rRangeStart;
-						$rEnd = $rRangeEnd;
-						$rLength = $rEnd - $rStart + 1;
-						header('HTTP/1.1 206 Partial Content');
-					} else {
-						header('HTTP/1.1 416 Requested Range Not Satisfiable');
-						header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-						exit();
-					}
-				} else {
-					header('HTTP/1.1 416 Requested Range Not Satisfiable');
-					header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-					exit();
-				}
+			$rServe = HttpRange::sendHeaders(HttpRange::parse($_SERVER['HTTP_RANGE'] ?? null, $rSize), $rSize);
+			if ($rServe === null) {
+				exit(); // 416 already sent
 			}
-
-			header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-			header('Content-Length: ' . $rLength);
-			$rStartFrom = 0;
-
-			if (0 >= $rStart) {
-			} else {
-				$rStartFrom = floor($rStart / ($rSize / count($rQueue)));
-			}
-
-			$rFirstFile = false;
-			$rSeekTo = 0;
-			$rSizeToDate = 0;
+			[$rStart, $rEnd] = $rServe;
+			$rLength = $rEnd - $rStart + 1;
+			$rRemaining = $rLength;
 			$rDownloadBytes = $rBitrate * 125;
 			$rDownloadBytes += $rDownloadBytes * $rSettings['vod_bitrate_plus'] * 0.01;
 			$rLastCheck = $rTimeChecked = $rTimeStart = time();
@@ -381,26 +337,40 @@ if ($rUserInfo) {
 
 			$rApplyLimit = false;
 
-			foreach ($rQueue as $rKey => $rItem) {
-				$rSizeToDate += $rItem['filesize'];
-
-				if ($rFirstFile || 0 >= $rStartFrom) {
-				} else {
-					if ($rKey < $rStartFrom) {
-					} else {
-						$rFirstFile = true;
-						$rSeekTo = $rStart - $rSizeToDate;
-					}
+			// Map the served byte range onto the files: skip every file that ends
+			// before $rStart, seek into the one it falls in, stop after $rEnd. (A
+			// seek used to estimate the start file from the average file size, never
+			// skip the files before it, and seek to a negative offset — so every
+			// catch-up seek streamed from the archive's first byte.)
+			$rPosition = 0; // response offset of the current file's first servable byte
+			foreach (array_values($rQueue) as $rIndex => $rItem) {
+				if ($rRemaining <= 0) {
+					break;
+				}
+				$rFileStart = ($rIndex === 0 ? $rOffset : 0);
+				$rFileBytes = $rItem['filesize'] - $rFileStart;
+				if ($rFileBytes <= 0) {
+					continue;
+				}
+				if ($rPosition + $rFileBytes <= $rStart) {
+					$rPosition += $rFileBytes; // wholly before the range
+					continue;
 				}
 
 				$rFP = fopen($rItem['filename'], 'rb');
-				fseek($rFP, $rSeekTo + $rOffset);
-				$rOffset = 0;
+				if (!$rFP) {
+					break;
+				}
+				fseek($rFP, $rFileStart + max(0, $rStart - $rPosition));
+				$rPosition += $rFileBytes;
 
-				while (!feof($rFP)) {
-					$rPosition = ftell($rFP);
-					$rResponse = stream_get_line($rFP, $rBuffer);
+				while (!feof($rFP) && 0 < $rRemaining) {
+					$rResponse = stream_get_line($rFP, (int) min($rBuffer, $rRemaining));
+					if ($rResponse === false || $rResponse === '') {
+						break;
+					}
 					echo $rResponse;
+					$rRemaining -= strlen($rResponse);
 					$rBytesRead += strlen($rResponse);
 					$i++;
 
@@ -411,8 +381,11 @@ if ($rUserInfo) {
 					}
 
 					if (0 < $rDownloadBytes && $rApplyLimit && ceil($rDownloadBytes / $rBuffer) <= $i) {
-						// Use efficient sleep instead of blocking sleep
-						AsyncFileOperations::efficientSleep(1000000); // 1 second with better CPU usage
+						// Throttled to the recording's bitrate: one second's worth of
+						// chunks, then a second's pause. The count restarts after each
+						// pause — without the reset every later chunk paused a second.
+						AsyncFileOperations::efficientSleep(1000000);
+						$i = 0;
 					}
 					if (30 > time() - $rTimeStart) {
 					} else {
@@ -466,12 +439,9 @@ if ($rUserInfo) {
 					}
 				}
 
-				if (!is_resource($rFP)) {
-				} else {
+				if (is_resource($rFP)) {
 					fclose($rFP);
 				}
-
-				$rSeekTo = 0;
 			}
 	}
 } else {

--- a/src/Public/stream/vod.php
+++ b/src/Public/stream/vod.php
@@ -9,6 +9,7 @@ use XcVm\Infrastructure\Redis\RedisManager;
 use XcVm\Streaming\AsyncFileOperations;
 use XcVm\Streaming\Auth\StreamAuth;
 use XcVm\Streaming\Auth\StreamAuthMiddleware;
+use XcVm\Streaming\Delivery\HttpRange;
 use XcVm\Streaming\Lifecycle\ShutdownHandler;
 
 /**
@@ -173,7 +174,7 @@ if ($rChannelInfo) {
 		generateError('LINE_CREATE_FAIL');
 	}
 
-	StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent);
+	StreamAuth::validateConnections($rUserInfo, $rIsHMAC, $rIdentifier, $rIP, $rUserAgent, $rTokenData['uuid']);
 
 	if ($rSettings['redis_handler']) {
 		RedisManager::closeInstance();
@@ -255,54 +256,15 @@ if ($rChannelInfo) {
 		} else {
 			$rFP = @fopen($rRequest, 'rb');
 			$rSize = filesize($rRequest);
-			$rLength = $rSize;
-			$rStart = 0;
-			$rEnd = $rSize - 1;
-			header('Accept-Ranges: 0-' . $rLength);
-
-			if (empty($_SERVER['HTTP_RANGE'])) {
-			} else {
-				$rRangeStart = $rStart;
-				$rRangeEnd = $rEnd;
-				list(, $rRange) = explode('=', $_SERVER['HTTP_RANGE'], 2);
-
-				if (strpos($rRange, ',') === false) {
-
-
-
-
-					if ($rRange == '-') {
-						$rRangeStart = $rSize - substr($rRange, 1);
-					} else {
-						$rRange = explode('-', $rRange);
-						$rRangeStart = $rRange[0];
-						$rRangeEnd = (isset($rRange[1]) && is_numeric($rRange[1]) ? $rRange[1] : $rSize);
-					}
-
-					$rRangeEnd = ($rEnd < $rRangeEnd ? $rEnd : $rRangeEnd);
-
-					if (!($rRangeEnd < $rRangeStart || $rSize - 1 < $rRangeStart || $rSize <= $rRangeEnd)) {
-						$rStart = $rRangeStart;
-						$rEnd = $rRangeEnd;
-						$rLength = $rEnd - $rStart + 1;
-						fseek($rFP, $rStart);
-						header('HTTP/1.1 206 Partial Content');
-					} else {
-						header('HTTP/1.1 416 Requested Range Not Satisfiable');
-						header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-						exit();
-					}
-				} else {
-					header('HTTP/1.1 416 Requested Range Not Satisfiable');
-					header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-					exit();
-				}
+			$rServe = HttpRange::sendHeaders(HttpRange::parse($_SERVER['HTTP_RANGE'] ?? null, $rSize), $rSize);
+			if ($rServe === null) {
+				exit(); // 416 already sent
 			}
-
-			header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-			header('Content-Length: ' . $rLength);
+			[$rStart, $rEnd] = $rServe;
+			$rLength = $rEnd - $rStart + 1;
+			if (0 < $rStart) {
+				fseek($rFP, $rStart);
+			}
 			$rLastCheck = $rTimeStart = $rTimeChecked = time();
 			$rBytesRead = 0;
 			$rBuffer = $rSettings['read_buffer_size'];
@@ -318,7 +280,9 @@ if ($rChannelInfo) {
 			$rApplyLimit = false;
 
 			while (!feof($rFP) && ($p = ftell($rFP)) <= $rEnd) {
-				$rResponse = stream_get_line($rFP, $rBuffer);
+				// Never read past the range end: a bounded request (a player probing
+				// bytes=0-1, or fetching an index near the end) got a whole buffer.
+				$rResponse = stream_get_line($rFP, (int) min($rBuffer, $rEnd - $p + 1));
 				$i++;
 
 				if (!$rApplyLimit && $rLimitAt <= $o * $rBuffer) {
@@ -392,88 +356,53 @@ if ($rChannelInfo) {
 			exit();
 		}
 	} else {
-
-		$opts = array(
-			'http' => array(
-				'max_redirects' => '20',
-				'method' =>   "GET",
-				'timeout' => 122,
-				'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:101.0) Gecko/20100101 Firefox/101.0'
-			)
-		);
-		$context = stream_context_create($opts);
-		$rHeaders = get_headers($rDirectProxy, 1, $context);
-		$rContentType = (is_array($rHeaders['Content-Type']) ? $rHeaders['Content-Type'][count($rHeaders['Content-Type']) - 1] : $rHeaders['Content-Type']);
-		$rSize = $rLength = $rHeaders['Content-Length'];
-
-		if (0 < $rLength && in_array($rContentType, array('video/mp4', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp', 'video/x-flv', 'video/x-ms-wmv', 'video/quicktime', 'video/mp2t', 'video/mpeg', 'application/octet-stream'))) {
-			if (!$rHeaders['Location']) {
-			} else {
-				if (is_array($rHeaders['Location'])) {
-					$tmp = array_reverse($rHeaders['Location']);
-					$rDirectProxy = $tmp[0];
-				} else {
-					$rDirectProxy = $rHeaders['Location'];
+		// Direct-proxy VOD: relay the source. Its size and type are read with cURL
+		// — get_headers() goes through the https stream wrapper, which does not
+		// work under PHP-FPM here (every https source failed), and returned
+		// Content-Length as an array after a redirect. The final response's
+		// headers are kept; the body is not downloaded.
+		$rSourceUA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:101.0) Gecko/20100101 Firefox/101.0';
+		$rHeaders = array();
+		$ch = curl_init($rDirectProxy);
+		curl_setopt_array($ch, array(
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_MAXREDIRS => 20,
+			CURLOPT_CONNECTTIMEOUT => 10,
+			CURLOPT_TIMEOUT => 122,
+			CURLOPT_SSL_VERIFYPEER => 0,
+			CURLOPT_USERAGENT => $rSourceUA,
+			CURLOPT_HEADERFUNCTION => static function ($rHandle, $rLine) use (&$rHeaders) {
+				if (preg_match('#^HTTP/\S+\s+\d+#i', $rLine)) {
+					$rHeaders = array(); // a redirect hop: only the final response counts
+				} elseif (strpos($rLine, ':') !== false) {
+					[$rName, $rValue] = explode(':', $rLine, 2);
+					$rHeaders[strtolower(trim($rName))] = trim($rValue);
 				}
-				unset($rHeaders['Location']);
-			}
+				return strlen($rLine);
+			},
+			CURLOPT_WRITEFUNCTION => static function () {
+				return 0; // headers only: stop at the first body byte
+			},
+		));
+		curl_exec($ch);
+		$rDirectProxy = (string) (curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $rDirectProxy);
+		curl_close($ch);
 
+		$rSize = intval($rHeaders['content-length'] ?? 0);
+		$rContentType = strtolower(trim(explode(';', (string) ($rHeaders['content-type'] ?? ''))[0]));
+
+		if (0 < $rSize && in_array($rContentType, array('video/mp4', 'video/x-matroska', 'video/x-msvideo', 'video/3gpp', 'video/x-flv', 'video/x-ms-wmv', 'video/quicktime', 'video/mp2t', 'video/mpeg', 'application/octet-stream'), true)) {
 			header('Content-Type: ' . $rContentType);
-			header('Accept-Ranges: bytes');
-			$rStart = 0;
-			$rEnd = $rSize - 1;
-
-			if (empty($_SERVER['HTTP_RANGE'])) {
-			} else {
-				$rRangeStart = $rStart;
-				$rRangeEnd = $rEnd;
-				list(, $rRange) = explode('=', $_SERVER['HTTP_RANGE'], 2);
-
-				if (strpos($rRange, ',') === false) {
-
-
-
-
-					if ($rRange == '-') {
-						$rRangeStart = $rSize - substr($rRange, 1);
-					} else {
-						$rRange = explode('-', $rRange);
-						$rRangeStart = $rRange[0];
-						$rRangeEnd = (isset($rRange[1]) && is_numeric($rRange[1]) ? $rRange[1] : $rSize);
-					}
-
-					$rRangeEnd = ($rEnd < $rRangeEnd ? $rEnd : $rRangeEnd);
-
-					if (!($rRangeEnd < $rRangeStart || $rSize - 1 < $rRangeStart || $rSize <= $rRangeEnd)) {
-						$rStart = $rRangeStart;
-						$rEnd = $rRangeEnd;
-						$rLength = $rEnd - $rStart + 1;
-						header('HTTP/1.1 206 Partial Content');
-					} else {
-						header('HTTP/1.1 416 Requested Range Not Satisfiable');
-						header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-						exit();
-					}
-				} else {
-					header('HTTP/1.1 416 Requested Range Not Satisfiable');
-					header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-
-					exit();
-				}
+			$rServe = HttpRange::sendHeaders(HttpRange::parse($_SERVER['HTTP_RANGE'] ?? null, $rSize), $rSize);
+			if ($rServe === null) {
+				exit(); // 416 already sent
 			}
+			[$rStart, $rEnd] = $rServe;
 
-			header('Content-Range: bytes ' . $rStart . '-' . $rEnd . '/' . $rSize);
-			header('Content-Length: ' . $rLength);
 			$ch = curl_init();
-
-			if (!isset($_SERVER['HTTP_RANGE'])) {
-			} else {
-				preg_match('/bytes=(\\d+)-(\\d+)?/', $_SERVER['HTTP_RANGE'], $rMatches);
-				$rOffset = intval($rMatches[1]);
-				$rLength = $rSize - $rOffset - 1;
-				$rHeaders = array('Range: bytes=' . $rOffset . '-' . ($rOffset + $rLength));
-				curl_setopt($ch, CURLOPT_HTTPHEADER, $rHeaders);
+			if (0 < $rStart || $rEnd < $rSize - 1) {
+				// Ask the source for exactly the range this response promises.
+				curl_setopt($ch, CURLOPT_HTTPHEADER, array('Range: bytes=' . $rStart . '-' . $rEnd));
 			}
 
 			if (512 * 1024 * 1024 >= $rSize) {
@@ -489,10 +418,10 @@ if ($rChannelInfo) {
 			}
 
 			curl_setopt($ch, CURLOPT_BUFFERSIZE, 10 * 1024 * 1024);
-			curl_setopt($ch, CURLOPT_VERBOSE, 1);
 			curl_setopt($ch, CURLOPT_TIMEOUT, 0);
 			curl_setopt($ch, CURLOPT_URL, $rDirectProxy);
 			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+			curl_setopt($ch, CURLOPT_USERAGENT, $rSourceUA);
 			curl_setopt($ch, CURLOPT_HEADER, false);
 			curl_setopt($ch, CURLOPT_FRESH_CONNECT, true);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);

--- a/src/Streaming/AsyncFileOperations.php
+++ b/src/Streaming/AsyncFileOperations.php
@@ -32,10 +32,11 @@ class AsyncFileOperations {
     private static $fileCache = [];
 
     /**
-     * Cache TTL in microseconds (100ms)
-     * @var int
+     * Cache TTL in seconds (100 ms) — compared against microtime(true) deltas.
+     * (It was 100000, read as seconds: a "100 ms" cache that lasted 27 hours.)
+     * @var float
      */
-    private static $cacheTTL = 100000;
+    private static $cacheTTL = 0.1;
 
     /**
      * Non-blocking file existence check with intelligent polling
@@ -74,7 +75,6 @@ class AsyncFileOperations {
     private static function awaitFileWithInotify($file, $maxRetries, $delayMs) {
         try {
             $directory = dirname($file);
-            $filename = basename($file);
 
             $inotify = @inotify_init();
             if ($inotify === false) {
@@ -84,28 +84,34 @@ class AsyncFileOperations {
             // Watch directory for file creation
             @inotify_add_watch($inotify, $directory, IN_CREATE | IN_MOVED_TO | IN_CLOSE_WRITE);
 
-            $checkCount = 0;
-            $timeout = intval($maxRetries * max(1, intval($delayMs / 100)));
-
-            while ($checkCount < $maxRetries) {
+            // The budget is TIME (maxRetries × delayMs, as for polling), and every
+            // wait is bounded: a blocking inotify_read() never returned when the
+            // file was not created, and counting events instead of time let a busy
+            // directory use up the retries in milliseconds.
+            $deadline = microtime(true) + max(1, $maxRetries) * max(1, $delayMs) / 1000;
+            $slice = max(1000, $delayMs * 1000);
+            while (true) {
+                clearstatcache(true, $file);
                 if (file_exists($file)) {
                     @fclose($inotify);
+                    self::clearFileCache($file);
                     return true;
                 }
-
-                // Wait for inotify events with timeout
-                $events = @inotify_read($inotify);
-
-                if ($events === false) {
-                    usleep(max(1000, $delayMs * 1000));
+                $left = $deadline - microtime(true);
+                if ($left <= 0) {
+                    break;
                 }
-
-                $checkCount++;
+                $read = array($inotify);
+                $write = $except = null;
+                $wait = (int) min($slice, $left * 1000000);
+                if (@stream_select($read, $write, $except, 0, $wait) > 0) {
+                    @inotify_read($inotify); // drain; the loop re-checks the file
+                }
             }
 
             @fclose($inotify);
             return false;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return self::awaitFileWithPolling($file, $maxRetries, $delayMs);
         }
     }
@@ -124,7 +130,9 @@ class AsyncFileOperations {
 
         for ($i = 0; $i < $maxRetries; $i++) {
             // Check with stat() for better performance
+            clearstatcache(true, $file);
             if (@stat($file) !== false) {
+                self::clearFileCache($file); // a later readFile() must see the new file
                 return true;
             }
 
@@ -191,7 +199,9 @@ class AsyncFileOperations {
 
         for ($i = 0; $i < $maxRetries; $i++) {
             foreach ($files as $file) {
+                clearstatcache(true, $file);
                 if (@stat($file) !== false) {
+                    self::clearFileCache($file);
                     return $file;
                 }
             }

--- a/src/Streaming/Auth/StreamAuth.php
+++ b/src/Streaming/Auth/StreamAuth.php
@@ -92,15 +92,27 @@ class StreamAuth {
 		return (empty($rRedirectID) ? array_search(min($rPriorityServers), $rPriorityServers) : $rRedirectID);
 	}
 
-	public static function validateConnections($rUserInfo, $rIsHMAC = false, $rIdentifier = '', $rIP = null, $rUserAgent = null) {
+	/**
+	 * Enforce the line's (or HMAC identity's) connection limit after the current
+	 * request's connection was recorded.
+	 *
+	 * @param array       $rUserInfo  Line info (id, pair_id, max_connections).
+	 * @param mixed       $rIsHMAC    HMAC id, or falsy for a line.
+	 * @param string|null $rIdentifier HMAC identifier.
+	 * @param string|null $rIP        Requesting IP.
+	 * @param string|null $rUserAgent Requesting user agent.
+	 * @param string|null $rUUID      The current connection's uuid, which is never evicted.
+	 * @return void
+	 */
+	public static function validateConnections($rUserInfo, $rIsHMAC = false, $rIdentifier = '', $rIP = null, $rUserAgent = null, $rUUID = null) {
 		if ($rUserInfo['max_connections'] != 0) {
 			if (!$rIsHMAC) {
 				if (!empty($rUserInfo['pair_id'])) {
-					ConnectionLimiter::closeConnections($rUserInfo['pair_id'], $rUserInfo['max_connections'], null, '', $rIP, $rUserAgent);
+					ConnectionLimiter::closeConnections($rUserInfo['pair_id'], $rUserInfo['max_connections'], null, '', $rIP, $rUserAgent, $rUUID);
 				}
-				ConnectionLimiter::closeConnections($rUserInfo['id'], $rUserInfo['max_connections'], null, '', $rIP, $rUserAgent);
+				ConnectionLimiter::closeConnections($rUserInfo['id'], $rUserInfo['max_connections'], null, '', $rIP, $rUserAgent, $rUUID);
 			} else {
-				ConnectionLimiter::closeConnections(null, $rUserInfo['max_connections'], $rIsHMAC, $rIdentifier, $rIP, $rUserAgent);
+				ConnectionLimiter::closeConnections(null, $rUserInfo['max_connections'], $rIsHMAC, $rIdentifier, $rIP, $rUserAgent, $rUUID);
 			}
 		}
 	}

--- a/src/Streaming/Delivery/HLSGenerator.php
+++ b/src/Streaming/Delivery/HLSGenerator.php
@@ -5,7 +5,8 @@ namespace XcVm\Streaming\Delivery;
 use XcVm\Core\Util\Encryption;
 
 /**
- * HLSGenerator — h l s generator
+ * HLSGenerator — turns the xc_fanout daemon's in-RAM HLS playlist into the
+ * per-viewer, token-authenticated playlist a client receives.
  *
  * @package XC_VM_Streaming_Delivery
  * @author  Divarion_D <https://github.com/Divarion-D>
@@ -15,56 +16,13 @@ use XcVm\Core\Util\Encryption;
  */
 
 class HLSGenerator {
-	public static function generateHLS($rSettings, $rM3U8, $rUsername, $rPassword, $rStreamID, $rUUID, $rIP, $rIsHMAC = null, $rIdentifier = '', $rVideoCodec = 'h264', $rOnDemand = 0, $rServerID = null, $rProxyID = null) {
-		if (!file_exists($rM3U8)) {
-			return false;
-		}
-		$rSource = file_get_contents($rM3U8);
-		if ($rSettings['encrypt_hls']) {
-			$rKeyToken = Encryption::encrypt($rIP . '/' . $rStreamID, $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
-			$rSource = "#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI=\"" . (($rProxyID ? '/' . md5($rProxyID . '_' . $rServerID . '_' . OPENSSL_EXTRA) : '')) . '/key/' . $rKeyToken . "\",IV=0x" . bin2hex(file_get_contents(STREAMS_PATH . $rStreamID . '_.iv')) . "\n" . substr($rSource, 8, strlen($rSource) - 8);
-		}
-
-		if (preg_match('/#EXT-X-MAP:URI="(.*?)"/', $rSource, $rInitMatch)) {
-			$rInitSegment = $rInitMatch[1];
-			if ($rIsHMAC) {
-				$rInitToken = Encryption::encrypt('HMAC#' . $rIsHMAC . '/' . $rIdentifier . '/' . $rIP . '/' . $rStreamID . '/' . $rInitSegment . '/' . $rUUID . '/' . SERVER_ID . '/' . $rVideoCodec . '/' . $rOnDemand, $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
-			} else {
-				$rInitToken = Encryption::encrypt($rUsername . '/' . $rPassword . '/' . $rIP . '/' . $rStreamID . '/' . $rInitSegment . '/' . $rUUID . '/' . SERVER_ID . '/' . $rVideoCodec . '/' . $rOnDemand, $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
-			}
-			if ($rSettings['allow_cdn_access']) {
-				$rSource = str_replace('URI="' . $rInitSegment . '"', 'URI="' . (($rProxyID ? '/' . md5($rProxyID . '_' . $rServerID . '_' . OPENSSL_EXTRA) : '')) . '/hls/' . $rInitSegment . '?token=' . $rInitToken . '"', $rSource);
-			} else {
-				$rSource = str_replace('URI="' . $rInitSegment . '"', 'URI="' . (($rProxyID ? '/' . md5($rProxyID . '_' . $rServerID . '_' . OPENSSL_EXTRA) : '')) . '/hls/' . $rInitToken . '"', $rSource);
-			}
-		}
-
-		if (preg_match_all('/(.*?)\.(ts|m4s)/', $rSource, $rMatches)) {
-			foreach ($rMatches[0] as $rMatch) {
-				if ($rIsHMAC) {
-					$rToken = Encryption::encrypt('HMAC#' . $rIsHMAC . '/' . $rIdentifier . '/' . $rIP . '/' . $rStreamID . '/' . $rMatch . '/' . $rUUID . '/' . SERVER_ID . '/' . $rVideoCodec . '/' . $rOnDemand, $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
-				} else {
-					$rToken = Encryption::encrypt($rUsername . '/' . $rPassword . '/' . $rIP . '/' . $rStreamID . '/' . $rMatch . '/' . $rUUID . '/' . SERVER_ID . '/' . $rVideoCodec . '/' . $rOnDemand, $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
-				}
-				if ($rSettings['allow_cdn_access']) {
-					$rSource = str_replace($rMatch, (($rProxyID ? '/' . md5($rProxyID . '_' . $rServerID . '_' . OPENSSL_EXTRA) : '')) . '/hls/' . $rMatch . '?token=' . $rToken, $rSource);
-				} else {
-					$rSource = str_replace($rMatch, (($rProxyID ? '/' . md5($rProxyID . '_' . $rServerID . '_' . OPENSSL_EXTRA) : '')) . '/hls/' . $rToken, $rSource);
-				}
-			}
-			return $rSource;
-		}
-
-		return false;
-	}
-
 	/**
 	 * Tokenize the xc_fanout daemon's in-RAM HLS playlist (ADR 0003, Phase B).
-	 * The daemon lists plain segments by sequence (`<seq>.ts`); rewrite each into
-	 * the same per-segment auth'd URL scheme generateHLS() uses, but with a
-	 * segment name marked as a daemon segment (`<id>_d<seq>.ts`) so segment.php
-	 * proxies it from the daemon's RAM instead of tmpfs. Daemon HLS is always
-	 * plain mpegts (unencrypted) — callers gate on `!encrypt_hls`.
+	 * The daemon lists plain segments by sequence (`<seq>.ts`); each is rewritten
+	 * into a per-segment auth'd URL with a segment name marked as a daemon segment
+	 * (`<id>_d<seq>.ts`), which segment.php proxies from the daemon's RAM. When
+	 * encrypt_hls is on, the daemon serves AES-128-CBC segments (it was given the
+	 * stream's key/iv at ingest registration) and the #EXT-X-KEY line is added here.
 	 *
 	 * @param string $rPlaylist Raw daemon m3u8.
 	 * @return string|false Tokenized playlist, or false if it has no segments.
@@ -99,13 +57,14 @@ class HLSGenerator {
 		// live sequence to the same wall-clock base via a persisted per-stream offset
 		// so it only ever advances (see HlsSequence).
 		if (preg_match('/#EXT-X-MEDIA-SEQUENCE:(\d+)/', $rSource, $rSeqMatch)) {
-			$rSeq = HlsSequence::liveSequence((int) $rStreamID, (int) $rSeqMatch[1]);
+			$rTarget = preg_match('/#EXT-X-TARGETDURATION:(\d+)/', $rSource, $rTargetMatch) ? max(1, (int) $rTargetMatch[1]) : HlsSequence::SEG;
+			$rSeq = HlsSequence::liveSequence((int) $rStreamID, (int) $rSeqMatch[1], $rTarget);
 			$rSource = preg_replace('/#EXT-X-MEDIA-SEQUENCE:\d+/', '#EXT-X-MEDIA-SEQUENCE:' . $rSeq, $rSource, 1);
 		}
 
 		// Encrypted HLS: the daemon serves AES-128-CBC segments (it was given the
-		// same key/iv), so declare the key exactly like generateHLS — URI to the
-		// /key token endpoint, IV from the stream's iv file.
+		// same key/iv), so declare the key — URI to the /key token endpoint, IV
+		// from the stream's iv file.
 		if (!empty($rSettings['encrypt_hls'])) {
 			$rIVFile = STREAMS_PATH . intval($rStreamID) . '_.iv';
 			if (is_file($rIVFile)) {

--- a/src/Streaming/Delivery/HlsSequence.php
+++ b/src/Streaming/Delivery/HlsSequence.php
@@ -17,11 +17,18 @@ namespace XcVm\Streaming\Delivery;
  * (MEDIA-SEQUENCE must never decrease), stalling the player during warm-up.
  *
  * This re-anchors the live sequence to the same wall-clock base via a tiny
- * persisted per-stream offset, so the published value only ever advances: it stays
- * ≥ the off-air line and ≥ whatever the last live window showed, while still
- * incrementing by the daemon's own per-segment delta so segment identity is
- * preserved. The off-air handler is left untouched (it has no stream id and stays
- * stream-agnostic); anchoring only the live side is enough for a smooth transition.
+ * persisted per-stream offset, so the published value only ever advances, while
+ * still incrementing by the daemon's own per-segment delta so segment identity is
+ * preserved.
+ *
+ * The wall-clock floor is applied only where a player can actually have seen the
+ * off-air loop: the first publish, a daemon counter that went backwards (a
+ * restart), a publish gap long enough for the loop to have been served, or an
+ * explicit {@see markOffAir()}. Applying it on every publish renumbered a stream
+ * whose segments run longer than SEG seconds (seg_time above 10, or keyframes
+ * that stretch segments past it): the daemon's counter falls behind the wall
+ * clock, and each catch-up shifted every listed segment by one — players replayed
+ * or skipped a segment several times a minute.
  *
  * @package XC_VM_Streaming_Delivery
  * @author  Divarion_D <https://github.com/Divarion-D>
@@ -33,31 +40,38 @@ class HlsSequence {
 	/**
 	 * Segment duration (seconds) the wall-clock base is measured in. MUST match the
 	 * off-air placeholder's sequence divisor / `#EXT-X-TARGETDURATION` in
-	 * {@see OffAirHandler::showNotOnAir()} so the live and off-air playlists share
-	 * one wall-clock-aligned sequence line.
+	 * {@see OffAirHandler::showVideoServer()} so the live and off-air playlists
+	 * share one wall-clock-aligned sequence line.
 	 */
-	private const SEG = 10;
+	public const SEG = 10;
+
+	/** A publish gap longer than this many target durations may hide an off-air loop. */
+	private const STALE_TARGETS = 3;
+
+	/** ...and never shorter than this many seconds. */
+	private const STALE_MIN_SEC = 30;
 
 	/**
 	 * The published live MEDIA-SEQUENCE for a stream: the daemon's 0-based segment
 	 * counter re-anchored to the off-air wall-clock base so it never drops below
-	 * what a player last saw. Persists a tiny per-stream `{base,last}` file under
-	 * STREAMS_PATH, guarded by flock for concurrent viewers. On any I/O failure (or
-	 * before STREAMS_PATH is defined) it degrades to a time-aligned value that is
+	 * what a player last saw. Persists a tiny per-stream state file (see
+	 * stateFile()), guarded by flock for concurrent viewers. On any I/O failure (or
+	 * before the paths are defined) it degrades to a time-aligned value that is
 	 * still ≥ the off-air line, never throwing.
 	 *
-	 * @param int $rStreamID Stream id.
+	 * @param int $rStreamID  Stream id.
 	 * @param int $rDaemonSeq The daemon playlist's own `#EXT-X-MEDIA-SEQUENCE`.
+	 * @param int $rTarget    The daemon playlist's `#EXT-X-TARGETDURATION` (seconds).
 	 * @return int The monotonic, off-air-aligned sequence to publish.
 	 */
-	public static function liveSequence(int $rStreamID, int $rDaemonSeq): int {
-		$rFloor = intdiv(time(), self::SEG);
-		if (!defined('STREAMS_PATH')) {
+	public static function liveSequence(int $rStreamID, int $rDaemonSeq, int $rTarget = self::SEG): int {
+		$rNow = time();
+		$rFloor = intdiv($rNow, self::SEG);
+		if (!defined('SIGNALS_TMP_PATH')) {
 			return max($rDaemonSeq, $rFloor);
 		}
 
-		$rFile = STREAMS_PATH . $rStreamID . '_.hlsseq';
-		$rFp = @fopen($rFile, 'c+');
+		$rFp = @fopen(self::stateFile($rStreamID), 'c+');
 		if ($rFp === false) {
 			return max($rDaemonSeq, $rFloor);
 		}
@@ -67,7 +81,7 @@ class HlsSequence {
 			$rRaw = stream_get_contents($rFp);
 			$rState = (is_string($rRaw) && $rRaw !== '') ? json_decode($rRaw, true) : null;
 
-			[$rSeq, $rNext] = self::reconcile($rDaemonSeq, $rFloor, is_array($rState) ? $rState : null);
+			[$rSeq, $rNext] = self::reconcile($rDaemonSeq, $rFloor, is_array($rState) ? $rState : null, $rNow, $rTarget);
 
 			ftruncate($rFp, 0);
 			rewind($rFp);
@@ -82,32 +96,90 @@ class HlsSequence {
 	}
 
 	/**
+	 * Record that a player of this stream was just served the off-air loop, so the
+	 * next live publish re-anchors at or above the loop's wall-clock sequence even
+	 * when the daemon's counter ran on uninterrupted (a brief outage).
+	 *
+	 * @param int $rStreamID Stream id.
+	 * @return void
+	 */
+	public static function markOffAir(int $rStreamID): void {
+		if (!defined('SIGNALS_TMP_PATH')) {
+			return;
+		}
+		$rFp = @fopen(self::stateFile($rStreamID), 'c+');
+		if ($rFp === false) {
+			return;
+		}
+		try {
+			@flock($rFp, LOCK_EX);
+			$rRaw = stream_get_contents($rFp);
+			$rState = (is_string($rRaw) && $rRaw !== '') ? json_decode($rRaw, true) : null;
+			if (!is_array($rState) || !isset($rState['at'])) {
+				return; // no live publish to follow yet: the first one anchors anyway
+			}
+			$rState['at'] = 0;
+			ftruncate($rFp, 0);
+			rewind($rFp);
+			fwrite($rFp, (string) json_encode($rState));
+			fflush($rFp);
+		} finally {
+			@flock($rFp, LOCK_UN);
+			fclose($rFp);
+		}
+	}
+
+	/**
 	 * Pure re-anchoring step (no I/O): given the daemon's current sequence, the
-	 * off-air wall-clock floor (`floor(time()/SEG)`) and the prior persisted state
-	 * (`{base,last}`, or null on first use), return `[publishedSequence, newState]`.
+	 * off-air wall-clock floor (`floor(time()/SEG)`) and the prior persisted state,
+	 * return `[publishedSequence, newState]`.
 	 *
 	 * Invariants:
 	 *   - the published sequence never decreases (≥ prior `last`);
-	 *   - it never drops below the off-air floor (so off-air → live is smooth);
-	 *   - while the daemon counter runs uninterrupted, `base` stays fixed, so the
-	 *     published value advances by exactly the daemon's per-segment delta.
-	 * A daemon restart (counter reset to 0) or a stale/low state only ever bumps
-	 * `base` UP, so the sequence keeps climbing — never a backward step.
+	 *   - wherever a player may have seen the off-air loop — first use, a daemon
+	 *     restart, a stale or off-air-marked state, or when $rNow is not given — it
+	 *     is at least the off-air floor;
+	 *   - while the daemon counter runs uninterrupted and publishes stay fresh,
+	 *     `base` stays fixed, so the published value advances by exactly the
+	 *     daemon's per-segment delta — even when that is slower than the floor.
 	 *
-	 * @param array{base?:int,last?:int}|null $rState
-	 * @return array{0:int,1:array{base:int,last:int}}
+	 * @param array{base?:int,last?:int,daemon?:int,at?:int}|null $rState
+	 * @param int|null $rNow    Current time, or null to always apply the floor.
+	 * @param int      $rTarget Target segment duration (seconds), sizing the stale gap.
+	 * @return array{0:int,1:array<string,int>}
 	 */
-	public static function reconcile(int $rDaemonSeq, int $rFloor, ?array $rState): array {
+	public static function reconcile(int $rDaemonSeq, int $rFloor, ?array $rState, ?int $rNow = null, int $rTarget = self::SEG): array {
 		$rBase = isset($rState['base']) ? (int) $rState['base'] : 0;
 		$rLast = isset($rState['last']) ? (int) $rState['last'] : 0;
 
+		$rContinuous = $rNow !== null
+			&& isset($rState['daemon'], $rState['at'])
+			&& $rDaemonSeq >= (int) $rState['daemon']
+			&& $rNow - (int) $rState['at'] <= max(self::STALE_MIN_SEC, self::STALE_TARGETS * max(1, $rTarget));
+
 		$rSeq = $rDaemonSeq + $rBase;
-		$rMin = max($rLast, $rFloor);
+		$rMin = $rContinuous ? $rLast : max($rLast, $rFloor);
 		if ($rSeq < $rMin) {
-			$rBase = $rMin - $rDaemonSeq; // re-anchor: first on-air, daemon restart, or a time skip
+			$rBase = $rMin - $rDaemonSeq; // re-anchor: first on-air, daemon restart, or back from off-air
 			$rSeq = $rMin;
 		}
 
-		return [$rSeq, ['base' => $rBase, 'last' => $rSeq]];
+		$rNext = array('base' => $rBase, 'last' => $rSeq);
+		if ($rNow !== null) {
+			$rNext['daemon'] = $rDaemonSeq;
+			$rNext['at'] = $rNow;
+		}
+		return [$rSeq, $rNext];
+	}
+
+	/**
+	 * The per-stream state lives with the other runtime markers, not beside the
+	 * stream's files: a restart wipes `STREAMS_PATH/<id>_*`, and losing `last` there
+	 * let the first publish after a restart step back under what a player that
+	 * stayed connected had already seen. TmpCronJob ages it out once a stream has
+	 * gone unwatched for ten minutes.
+	 */
+	private static function stateFile(int $rStreamID): string {
+		return SIGNALS_TMP_PATH . 'hlsseq_' . $rStreamID;
 	}
 }

--- a/src/Streaming/Delivery/HttpRange.php
+++ b/src/Streaming/Delivery/HttpRange.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace XcVm\Streaming\Delivery;
+
+/**
+ * HttpRange — one parser for the single byte ranges the VOD and timeshift
+ * endpoints serve (RFC 7233).
+ *
+ * The endpoints used to parse `Range` inline, and the copies had drifted into
+ * the same bugs: a suffix range (`bytes=-500`, the last 500 bytes) was read as a
+ * start of '' and died on PHP 8 arithmetic, and an unsatisfiable range answered
+ * with the full resource's range instead of `bytes *\/size`.
+ */
+final class HttpRange {
+	/**
+	 * Resolve a Range header against a resource size.
+	 *
+	 * @param string|null $rHeader The Range header value (e.g. "bytes=0-1023"), or null/'' for none.
+	 * @param int         $rSize   Resource size in bytes.
+	 * @return array{0:int,1:int}|null|false [first, last] byte offsets (inclusive) for a
+	 *         satisfiable single range; null when there is no usable Range (serve the
+	 *         whole resource, 200); false when it cannot be satisfied (416).
+	 */
+	public static function parse(?string $rHeader, int $rSize) {
+		if ($rHeader === null || trim($rHeader) === '') {
+			return null;
+		}
+		if (!preg_match('/^\s*bytes\s*=\s*(.+)$/i', $rHeader, $rMatch)) {
+			return null; // another unit: ignore the header, as RFC 7233 allows
+		}
+		$rSpec = trim($rMatch[1]);
+		if (strpos($rSpec, ',') !== false) {
+			return false; // multipart/byteranges is not served
+		}
+		if (!preg_match('/^(\d*)\s*-\s*(\d*)$/', $rSpec, $rParts) || ($rParts[1] === '' && $rParts[2] === '')) {
+			return false;
+		}
+		if ($rSize <= 0) {
+			return false;
+		}
+
+		if ($rParts[1] === '') {
+			// Suffix range: the last N bytes.
+			$rLength = (int) $rParts[2];
+			if ($rLength <= 0) {
+				return false;
+			}
+			return array(max(0, $rSize - $rLength), $rSize - 1);
+		}
+
+		$rFirst = (int) $rParts[1];
+		$rLast = ($rParts[2] === '') ? $rSize - 1 : min((int) $rParts[2], $rSize - 1);
+		if ($rFirst >= $rSize || $rLast < $rFirst) {
+			return false;
+		}
+		return array($rFirst, $rLast);
+	}
+
+	/**
+	 * Send the headers for a resolved range: 206 + Content-Range for a range, 200
+	 * for the whole resource, or 416 + `bytes *\/size` for an unsatisfiable one.
+	 *
+	 * @param array{0:int,1:int}|null|false $rRange What parse() returned.
+	 * @param int                           $rSize  Resource size in bytes.
+	 * @return array{0:int,1:int}|null [first, last] to send, or null after a 416 (send no body).
+	 */
+	public static function sendHeaders($rRange, int $rSize): ?array {
+		header('Accept-Ranges: bytes');
+		if ($rRange === false) {
+			header('HTTP/1.1 416 Requested Range Not Satisfiable');
+			header('Content-Range: bytes */' . $rSize);
+			return null;
+		}
+		if ($rRange === null) {
+			header('Content-Length: ' . $rSize);
+			return array(0, $rSize - 1);
+		}
+		header('HTTP/1.1 206 Partial Content');
+		header('Content-Range: bytes ' . $rRange[0] . '-' . $rRange[1] . '/' . $rSize);
+		header('Content-Length: ' . ($rRange[1] - $rRange[0] + 1));
+		return $rRange;
+	}
+}

--- a/src/Streaming/Delivery/OffAirHandler.php
+++ b/src/Streaming/Delivery/OffAirHandler.php
@@ -18,6 +18,21 @@ use XcVm\Streaming\Balancer\ProxySelector;
  */
 
 class OffAirHandler {
+	/** The live stream this request serves, when known (live.php sets it). */
+	private static ?int $rHlsStreamID = null;
+
+	/**
+	 * Name the live stream this request is for, so an off-air HLS playlist served
+	 * in its place can tell HlsSequence — the next live playlist then numbers its
+	 * segments above the loop the player was shown.
+	 *
+	 * @param int $rStreamID Stream id.
+	 * @return void
+	 */
+	public static function forStream(int $rStreamID): void {
+		self::$rHlsStreamID = $rStreamID;
+	}
+
 	public static function getOffAirVideo($rPathKey) {
 		global $rSettings;
 		if (!(isset($rSettings[$rPathKey]) && 0 < strlen($rSettings[$rPathKey]))) {
@@ -72,7 +87,7 @@ class OffAirHandler {
 	public static function showVideoServer($rShowOptionKey, $rVideoPathKey, $rExtension, $rUserInfo, $rIP, $rCountryCode, $rISP, $rServerID = null, $rProxyID = null) {
 		global $rSettings, $rServers;
 		$rVideoPath = self::getOffAirVideo($rVideoPathKey);
-		if (!(!$rUserInfo['is_restreamer'] && $rSettings[$rShowOptionKey] && 0 < strlen($rVideoPath))) {
+		if (!(!$rUserInfo['is_restreamer'] && $rSettings[$rShowOptionKey] && 0 < strlen((string) $rVideoPath))) {
 			switch ($rShowOptionKey) {
 				case 'show_expired_video':
 					generateError('EXPIRED');
@@ -115,7 +130,10 @@ class OffAirHandler {
 		$rTokenData = array('expires' => time() + 10, 'video_path' => $rVideoPath);
 		$rToken = Encryption::encrypt(json_encode($rTokenData), $rSettings['live_streaming_pass'], OPENSSL_EXTRA);
 		if ($rExtension == 'm3u8') {
-			$segmentDuration = 10;
+			if (self::$rHlsStreamID !== null) {
+				HlsSequence::markOffAir(self::$rHlsStreamID);
+			}
+			$segmentDuration = HlsSequence::SEG;
 			$sequence = intval(time() / $segmentDuration);
 			$rM3U8 = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:{$sequence}\n#EXT-X-ALLOW-CACHE:NO\n#EXT-X-TARGETDURATION:{$segmentDuration}\n#EXT-X-PLAYLIST-TYPE:EVENT\n";
 			for ($i = 0; $i < 3; $i++) {

--- a/src/Streaming/Fanout/FanoutClient.php
+++ b/src/Streaming/Fanout/FanoutClient.php
@@ -340,6 +340,25 @@ class FanoutClient {
 	}
 
 	/**
+	 * Disconnect a daemon-served live-TS viewer by its connection uuid (control
+	 * DELETE /connections/<uuid>). Under X-Accel the PHP worker that admitted the
+	 * viewer returned at hand-off, so this is the only way a connection-limit
+	 * eviction or an admin kick can end the session — deleting the viewer's row
+	 * alone left it streaming, untracked.
+	 *
+	 * @param string $rUUID Viewer connection uuid (the X-Accel `?c=` value).
+	 * @return bool True when the daemon dropped a connection (204); false when the
+	 *              uuid is not connected to this node's daemon, the daemon predates
+	 *              the endpoint, or it is unreachable.
+	 */
+	public static function dropConnection(string $rUUID): bool {
+		if ($rUUID === '') {
+			return false;
+		}
+		return self::request('DELETE', '/connections/' . rawurlencode($rUUID), null, 1, 2)['code'] === 204;
+	}
+
+	/**
 	 * Per-viewer average delivery rate (KB/s since attach), keyed by connection
 	 * uuid, across all daemon streams (control GET /rates). This is the daemon
 	 * replacement for the legacy chase-read loop's DIVERGENCE_TMP_PATH speed

--- a/src/Streaming/Fanout/IngestFeeder.php
+++ b/src/Streaming/Fanout/IngestFeeder.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace XcVm\Streaming\Fanout;
+
+/**
+ * IngestFeeder — how a PHP producer (the LLOD segmenter, the loopback relay, the
+ * delay worker) pushes a stream's MPEG-TS into the xc_fanout daemon.
+ *
+ * Since ADR 0003 Phase E the daemon is the only thing that serves clients, so for
+ * these producers the feed IS the channel's delivery, not a best-effort mirror of
+ * an on-disk path that no longer exists. Three things follow:
+ *
+ *  - a short write must not tear packets: what the socket does not take is kept
+ *    and sent first on the next call (plain non-blocking fwrite() silently dropped
+ *    the remainder, corrupting whatever it cut through);
+ *  - the producer's own loop must never stall on the daemon: writes stay
+ *    non-blocking, and a backlog past MAX_BACKLOG sheds its OLDEST whole packets
+ *    (the daemon resyncs on the next PAT/PMT);
+ *  - a daemon restart must not leave the channel dark until the producer happens
+ *    to restart: a dead connection is re-registered (a restarted daemon hands out
+ *    a fresh socket) and redialled, with a backoff.
+ *
+ * Input must be whole 188-byte packets. The only partial packet ever in flight is
+ * the head of the backlog after a short write; on reconnect its unsent tail is
+ * discarded so the new connection starts on a packet boundary.
+ */
+final class IngestFeeder {
+	private const PACKET = 188;
+	/** Backlog ceiling (bytes) — roughly ten seconds of an HD stream. */
+	private const MAX_BACKLOG = 8388608;
+	/** Seconds between reconnect attempts. */
+	private const RETRY_SEC = 2.0;
+
+	private int $streamID;
+	private ?string $keyHex;
+	private ?string $ivHex;
+	/** @var callable|null fn(string $message): void */
+	private $logger;
+	/** @var callable fn(int $id, ?string $key, ?string $iv): ?string */
+	private $register;
+	/** @var callable fn(string $socket): resource|false */
+	private $dial;
+
+	/** @var resource|null */
+	private $conn = null;
+	private string $pending = '';
+	/** Bytes of the backlog's head packet already written to the current connection. */
+	private int $headSent = 0;
+	private float $retryAt = 0.0;
+	private int $droppedPackets = 0;
+
+	/**
+	 * @param int           $rStreamID Stream id (the daemon key).
+	 * @param string|null   $rKeyHex   Hex AES-128 key when the stream's HLS is encrypted.
+	 * @param string|null   $rIVHex    Hex AES-128-CBC IV to go with it.
+	 * @param callable|null $rLogger   Receives one line per state change.
+	 * @param callable|null $rRegister Registers the ingest, returns the socket path
+	 *                                 (defaults to FanoutClient::registerIngest).
+	 * @param callable|null $rDial     Opens the socket (defaults to a unix-socket dial).
+	 */
+	public function __construct(int $rStreamID, ?string $rKeyHex = null, ?string $rIVHex = null, ?callable $rLogger = null, ?callable $rRegister = null, ?callable $rDial = null) {
+		$this->streamID = $rStreamID;
+		$this->keyHex = $rKeyHex;
+		$this->ivHex = $rIVHex;
+		$this->logger = $rLogger;
+		$this->register = $rRegister ?? static function (int $rID, ?string $rKey, ?string $rIV): ?string {
+			return FanoutClient::registerIngest($rID, $rKey, $rIV);
+		};
+		$this->dial = $rDial ?? static function (string $rSocket) {
+			return @stream_socket_client('unix://' . $rSocket, $rErrno, $rErrstr, 2);
+		};
+	}
+
+	/**
+	 * A feeder for a stream, carrying its HLS key/iv (the `_.key`/`_.iv` files the
+	 * launcher wrote) when encrypted HLS is on — without them the daemon serves
+	 * plain segments under a playlist that declares AES-128, and nothing plays.
+	 *
+	 * @param int           $rStreamID Stream id.
+	 * @param bool          $rEncrypt  The encrypt_hls setting.
+	 * @param callable|null $rLogger   See the constructor.
+	 * @return self
+	 */
+	public static function forStream(int $rStreamID, bool $rEncrypt, ?callable $rLogger = null): self {
+		[$rKey, $rIV] = $rEncrypt ? self::streamKey($rStreamID) : array(null, null);
+		return new self($rStreamID, $rKey, $rIV, $rLogger);
+	}
+
+	/**
+	 * The stream's HLS key and IV as hex, or [null, null] when either file is
+	 * missing or malformed.
+	 *
+	 * @param int $rStreamID Stream id.
+	 * @return array{0:?string,1:?string}
+	 */
+	public static function streamKey(int $rStreamID): array {
+		if (!defined('STREAMS_PATH')) {
+			return array(null, null);
+		}
+		$rKey = @file_get_contents(STREAMS_PATH . $rStreamID . '_.key');
+		$rIV = @file_get_contents(STREAMS_PATH . $rStreamID . '_.iv');
+		if (!is_string($rKey) || strlen($rKey) !== 16 || !is_string($rIV) || strlen($rIV) !== 16) {
+			return array(null, null);
+		}
+		return array(bin2hex($rKey), bin2hex($rIV));
+	}
+
+	/**
+	 * Register the ingest and dial it now (rather than on the first write).
+	 *
+	 * @return bool True when connected.
+	 */
+	public function connect(): bool {
+		if ($this->conn) {
+			return true;
+		}
+		$rSocket = ($this->register)($this->streamID, $this->keyHex, $this->ivHex);
+		if ($rSocket === null || $rSocket === '') {
+			$this->retryAt = microtime(true) + self::RETRY_SEC;
+			return false;
+		}
+		$rConn = ($this->dial)($rSocket);
+		if (!is_resource($rConn)) {
+			$this->log('[fanout] could not connect to the daemon ingest socket ' . $rSocket);
+			$this->retryAt = microtime(true) + self::RETRY_SEC;
+			return false;
+		}
+		stream_set_blocking($rConn, false);
+		$this->conn = $rConn;
+		$this->headSent = 0;
+		$this->log('[fanout] feeding the daemon ingest');
+		return true;
+	}
+
+	/** @return bool Whether a connection to the daemon is open. */
+	public function isConnected(): bool {
+		return (bool) $this->conn;
+	}
+
+	/** @return int Bytes waiting to be written. */
+	public function backlog(): int {
+		return strlen($this->pending);
+	}
+
+	/** @return int Whole packets shed because the backlog overflowed. */
+	public function droppedPackets(): int {
+		return $this->droppedPackets;
+	}
+
+	/**
+	 * Queue whole TS packets for the daemon and send what the socket takes now.
+	 *
+	 * @param string $rData Whole 188-byte packets.
+	 * @return void
+	 */
+	public function write(string $rData): void {
+		if ($rData !== '') {
+			$this->pending .= $rData;
+			$this->shedOverflow();
+		}
+		$this->flush();
+	}
+
+	/**
+	 * Send as much of the backlog as the socket takes without blocking; reconnect
+	 * first when the connection is down and the backoff has passed. Call it from
+	 * the producer's loop even when there is nothing new to write.
+	 *
+	 * @return void
+	 */
+	public function flush(): void {
+		if (!$this->conn) {
+			if (microtime(true) < $this->retryAt || !$this->connect()) {
+				return;
+			}
+		}
+		while ($this->pending !== '') {
+			$rWritten = @fwrite($this->conn, $this->pending);
+			if ($rWritten === false) {
+				$this->drop('[fanout] the daemon ingest connection failed; reconnecting');
+				return;
+			}
+			if ($rWritten === 0) {
+				return; // socket buffer full — the rest goes on the next call
+			}
+			$this->pending = (string) substr($this->pending, $rWritten);
+			$this->headSent = ($this->headSent + $rWritten) % self::PACKET;
+		}
+	}
+
+	/**
+	 * Close the connection. The daemon keeps the stream registered; viewers wait
+	 * for the next producer rather than being dropped.
+	 *
+	 * @return void
+	 */
+	public function close(): void {
+		if ($this->conn) {
+			@fclose($this->conn);
+		}
+		$this->conn = null;
+	}
+
+	/**
+	 * Tear the connection down after a failure: discard the rest of a packet the
+	 * old connection only half received, so the next one starts aligned.
+	 */
+	private function drop(string $rWhy): void {
+		$this->close();
+		if ($this->headSent > 0) {
+			$this->pending = (string) substr($this->pending, self::PACKET - $this->headSent);
+			$this->headSent = 0;
+		}
+		$this->retryAt = microtime(true) + self::RETRY_SEC;
+		$this->log($rWhy);
+	}
+
+	/**
+	 * Keep the backlog under MAX_BACKLOG by dropping its oldest whole packets —
+	 * never the partially written head packet, which the connection still needs
+	 * to complete.
+	 */
+	private function shedOverflow(): void {
+		$rExcess = strlen($this->pending) - self::MAX_BACKLOG;
+		if ($rExcess <= 0) {
+			return;
+		}
+		$rKeep = $this->headSent > 0 ? self::PACKET - $this->headSent : 0;
+		$rShed = (int) (ceil($rExcess / self::PACKET) * self::PACKET);
+		$this->pending = substr($this->pending, 0, $rKeep) . substr($this->pending, $rKeep + $rShed);
+		$this->droppedPackets += intdiv($rShed, self::PACKET);
+	}
+
+	private function log(string $rMessage): void {
+		if ($this->logger) {
+			($this->logger)($rMessage);
+		}
+	}
+}

--- a/src/Streaming/Protection/ConnectionLimiter.php
+++ b/src/Streaming/Protection/ConnectionLimiter.php
@@ -21,12 +21,36 @@ class ConnectionLimiter {
 		ConnectionTracker::writeOfflineActivity($rSettings, intval($rServerID), intval($rProxyID ?? 0), intval($rUserID), intval($rStreamID), intval($rStart), strval($rUserAgent), strval($rIP), strval($rExtension), strval($rGeoIP), strval($rISP), $rExternalDevice, intval($rDivergence), $rIsHMAC, $rIdentifier);
 	}
 
-	public static function closeConnections($rUserID, $rMaxConnections, $rIsHMAC = null, $rIdentifier = '', $rIP = null, $rUserAgent = null) {
+	/**
+	 * Enforce a line's connection limit by closing its oldest connections,
+	 * preferring ones from the requesting device (same IP + user agent), then the
+	 * same IP, then any.
+	 *
+	 * @param int|null    $rUserID        Line id (null for an HMAC identity).
+	 * @param int         $rMaxConnections The line's limit.
+	 * @param int|null    $rIsHMAC        HMAC id, or null for a line.
+	 * @param string      $rIdentifier    HMAC identifier.
+	 * @param string|null $rIP            Requesting IP.
+	 * @param string|null $rUserAgent     Requesting user agent.
+	 * @param string|null $rCurrentUUID   The requesting connection's uuid — never
+	 *                                    closed. A worker used to spare itself by
+	 *                                    pid, but a daemon-served viewer's row has
+	 *                                    pid 0, so the new viewer could evict itself.
+	 * @return int|null Connections closed, or null when within the limit.
+	 */
+	public static function closeConnections($rUserID, $rMaxConnections, $rIsHMAC = null, $rIdentifier = '', $rIP = null, $rUserAgent = null, $rCurrentUUID = null) {
 		global $rSettings, $rServers, $db;
 		$redis = RedisManager::instance();
 		if ($rSettings['redis_handler']) {
+			if (!$redis) {
+				return null;
+			}
 			$rConnections = array();
-			$rKeys = ConnectionTracker::getLineConnections($rUserID, true, true);
+			// An HMAC identity's connections are keyed by "<hmac_id>_<identifier>",
+			// not a line id (which is null for it).
+			$rIdentity = $rIsHMAC ? $rIsHMAC . '_' . $rIdentifier : intval($rUserID);
+			$rKeys = $redis->zRangeByScore('LINE#' . $rIdentity, '-inf', '+inf');
+			$rKeys = is_array($rKeys) ? $rKeys : array();
 			$rToKill = count($rKeys) - $rMaxConnections;
 			if ($rToKill > 0) {
 				foreach (array_map('igbinary_unserialize', $redis->mGet($rKeys)) as $rConnection) {
@@ -72,7 +96,8 @@ class ConnectionLimiter {
 			$i = 0;
 			while ($i < count($rConnections) && $rKilled < $rToKill) {
 				if ($rKilled != $rToKill) {
-					if ($rConnections[$i]['pid'] != getmypid()) {
+					$rIsCurrent = $rCurrentUUID !== null && ($rConnections[$i]['uuid'] ?? null) === $rCurrentUUID;
+					if (!$rIsCurrent && $rConnections[$i]['pid'] != getmypid()) {
 						if ($rConnections[$i]['user_ip'] == $rIP && $rConnections[$i]['user_agent'] == $rUserAgent && $rKillOwnIP == 2 || $rConnections[$i]['user_ip'] == $rIP && $rKillOwnIP == 1 || $rKillOwnIP == 0) {
 							if (self::closeConnection($rConnections[$i])) {
 								$rKilled++;
@@ -179,6 +204,16 @@ class ConnectionLimiter {
 				} else {
 					$db->query('UPDATE `lines_live` SET `hls_end` = 1 WHERE `activity_id` = ?', $rActivityInfo['activity_id']);
 				}
+				// segment.php serves a daemon HLS segment only while this marker
+				// exists: removing it ends the kicked player within one segment
+				// instead of at its next playlist refresh.
+				if ($rActivityInfo['server_id'] == SERVER_ID && !empty($rActivityInfo['uuid'])) {
+					@unlink(CONS_TMP_PATH . $rActivityInfo['uuid']);
+				}
+			} else if (intval($rActivityInfo['pid']) === 0) {
+				// Daemon-served live TS (ADR 0003): no worker to kill — the daemon
+				// serving it drops the uuid (directly, or via its node's signals).
+				ConnectionTracker::dropDaemonViewer($rActivityInfo);
 			} else {
 				if ($rActivityInfo['server_id'] == SERVER_ID) {
 					if ($rActivityInfo['pid'] != getmypid() && is_numeric($rActivityInfo['pid']) && 0 < $rActivityInfo['pid']) {

--- a/src/bin/nginx/conf/nginx.conf
+++ b/src/bin/nginx/conf/nginx.conf
@@ -199,6 +199,9 @@ http {
             fastcgi_param SCRIPT_FILENAME /home/xc_vm/Public/stream/index.php;
             fastcgi_param SCRIPT_NAME /public/stream/index.php;
             fastcgi_param XC_STREAM $1;
+            # The TCP peer before real_ip rewrites REMOTE_ADDR to the client:
+            # auth checks it (not a client-set header) for proxy-only servers.
+            fastcgi_param XC_PEER_ADDR $realip_remote_addr;
         }
 
         location ~* ^/images/(.*/)?index\.html$ {

--- a/tests/Unit/FanoutSyncOrphanTest.php
+++ b/tests/Unit/FanoutSyncOrphanTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use XcVm\Cli\Commands\FanoutSyncCommand;
+
+/**
+ * @covers \XcVm\Cli\Commands\FanoutSyncCommand::dropOrphans
+ *
+ * The reverse of fanout_sync's reconcile: a daemon viewer whose connection row is
+ * gone (kicked, reaped, expired line) is dropped once it has stayed orphaned for
+ * the grace period — and never one that still has an open row.
+ */
+final class FanoutSyncOrphanTest extends TestCase {
+
+	public function testOrphanIsDroppedOnlyAfterTheGrace(): void {
+		$rSync = new FanoutSyncCommand();
+		$rDropped = [];
+		$rDrop = function (string $rUUID) use (&$rDropped) {
+			$rDropped[] = $rUUID;
+		};
+		$rRows = [['uuid' => 'kept', 'hls_end' => 0]];
+
+		$this->assertSame([], $rSync->dropOrphans(['kept', 'orphan'], $rRows, 1000, $rDrop), 'first sighting: grace starts');
+		$this->assertSame([], $rSync->dropOrphans(['kept', 'orphan'], $rRows, 1010, $rDrop), 'still within the grace');
+		$this->assertSame(['orphan'], $rSync->dropOrphans(['kept', 'orphan'], $rRows, 1020, $rDrop));
+		$this->assertSame(['orphan'], $rDropped, 'the viewer with a row is never dropped');
+	}
+
+	public function testAViewerWhoseRowReturnsIsForgiven(): void {
+		$rSync = new FanoutSyncCommand();
+		$rDrop = function () {
+		};
+		$rSync->dropOrphans(['u'], [], 1000, $rDrop);
+		// The row reappears (a read racing its write): the grace resets.
+		$this->assertSame([], $rSync->dropOrphans(['u'], [['uuid' => 'u', 'hls_end' => 0]], 1015, $rDrop));
+		$this->assertSame([], $rSync->dropOrphans(['u'], [], 1025, $rDrop), 'orphaned again: a fresh grace');
+	}
+
+	public function testAClosedRowCountsAsGone(): void {
+		$rSync = new FanoutSyncCommand();
+		$rDrop = function () {
+		};
+		$rClosed = [['uuid' => 'k', 'hls_end' => 1]]; // kicked: closed, not yet reaped
+		$rSync->dropOrphans(['k'], $rClosed, 1000, $rDrop);
+		$this->assertSame(['k'], $rSync->dropOrphans(['k'], $rClosed, 1020, $rDrop));
+	}
+}

--- a/tests/Unit/HlsSequenceTest.php
+++ b/tests/Unit/HlsSequenceTest.php
@@ -67,6 +67,53 @@ final class HlsSequenceTest extends TestCase {
 		$this->assertGreaterThanOrEqual($offAirSeen, $live);
 	}
 
+	public function testLongSegmentsAreNeverRenumberedWhilePlaying() {
+		// 12 s segments against the 10 s off-air floor: the daemon counter falls
+		// behind the wall clock. Re-anchoring to the floor on every publish shifted
+		// every listed segment by one each time it caught up — players replayed or
+		// skipped a segment. With a fresh, uninterrupted run base must stay fixed.
+		$t0 = 1700000000;
+		$state = null;
+		$base = null;
+		for ($t = $t0; $t < $t0 + 600; $t += 2) {
+			$daemon = intdiv($t - $t0, 12);
+			[$seq, $state] = HlsSequence::reconcile($daemon, intdiv($t, 10), $state, $t, 12);
+			$base ??= $state['base'];
+			$this->assertSame($base, $state['base'], "renumbered at t+" . ($t - $t0));
+			$this->assertSame($daemon + $base, $seq);
+		}
+	}
+
+	public function testStalePublishReappliesTheFloor() {
+		// Nothing published for longer than the stale gap: a player may have been
+		// shown the off-air loop meanwhile, so the next live value is floored again.
+		$state = ['base' => 100, 'last' => 150, 'daemon' => 50, 'at' => 1000];
+		[$seq] = HlsSequence::reconcile(51, 500, $state, 1000 + 31, 6);
+		$this->assertSame(500, $seq);
+
+		// Within the gap the run is continuous and the floor is not applied.
+		[$seq] = HlsSequence::reconcile(51, 500, $state, 1000 + 20, 6);
+		$this->assertSame(151, $seq);
+	}
+
+	public function testOffAirMarkReappliesTheFloor() {
+		// markOffAir() zeroes `at`: even a daemon counter that ran on through a
+		// brief outage is re-anchored above the off-air loop the player just saw.
+		$state = ['base' => 100, 'last' => 150, 'daemon' => 50, 'at' => 0];
+		[$seq] = HlsSequence::reconcile(51, 500, $state, 1000, 6);
+		$this->assertSame(500, $seq);
+	}
+
+	public function testDaemonRestartWithFreshStateStillHolds() {
+		// A fresh state with a daemon counter that went BACKWARDS is a restart: hold
+		// at last (≥ floor), never step back.
+		$state = ['base' => 1000, 'last' => 1600, 'daemon' => 600, 'at' => 1000];
+		[$seq, $state] = HlsSequence::reconcile(0, 1200, $state, 1001, 6);
+		$this->assertSame(1600, $seq);
+		[$seq] = HlsSequence::reconcile(1, 1200, $state, 1007, 6);
+		$this->assertSame(1601, $seq);
+	}
+
 	public function testPublishedSequenceIsAlwaysMonotonic() {
 		// Property check: across an arbitrary run of daemon values, floors and a
 		// restart, the published sequence never decreases.

--- a/tests/Unit/HttpRangeTest.php
+++ b/tests/Unit/HttpRangeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use XcVm\Streaming\Delivery\HttpRange;
+
+/**
+ * @covers \XcVm\Streaming\Delivery\HttpRange
+ *
+ * The single-range parser the VOD and timeshift endpoints share. The inline
+ * copies it replaced broke on suffix ranges (`bytes=-N`) and answered an
+ * unsatisfiable range with the full resource's Content-Range.
+ */
+final class HttpRangeTest extends TestCase {
+
+	public function testNoRangeServesTheWholeResource(): void {
+		$this->assertNull(HttpRange::parse(null, 1000));
+		$this->assertNull(HttpRange::parse('', 1000));
+		$this->assertNull(HttpRange::parse('items=0-9', 1000), 'another unit is ignored');
+	}
+
+	public function testBoundedAndOpenRanges(): void {
+		$this->assertSame([0, 99], HttpRange::parse('bytes=0-99', 1000));
+		$this->assertSame([0, 1], HttpRange::parse('bytes=0-1', 1000), 'a player probing the first bytes');
+		$this->assertSame([500, 999], HttpRange::parse('bytes=500-', 1000));
+		$this->assertSame([10, 999], HttpRange::parse('bytes=10-5000', 1000), 'end clamped to the size');
+		$this->assertSame([10, 20], HttpRange::parse(' Bytes = 10 - 20 ', 1000));
+	}
+
+	public function testSuffixRangeIsTheLastBytes(): void {
+		$this->assertSame([900, 999], HttpRange::parse('bytes=-100', 1000));
+		$this->assertSame([0, 999], HttpRange::parse('bytes=-5000', 1000), 'longer than the resource: all of it');
+	}
+
+	public function testUnsatisfiableRanges(): void {
+		$this->assertFalse(HttpRange::parse('bytes=1000-', 1000), 'starts past the end');
+		$this->assertFalse(HttpRange::parse('bytes=5-2', 1000), 'end before start');
+		$this->assertFalse(HttpRange::parse('bytes=-0', 1000), 'empty suffix');
+		$this->assertFalse(HttpRange::parse('bytes=0-1,5-6', 1000), 'multipart is not served');
+		$this->assertFalse(HttpRange::parse('bytes=abc', 1000));
+		$this->assertFalse(HttpRange::parse('bytes=-', 1000));
+		$this->assertFalse(HttpRange::parse('bytes=0-9', 0), 'nothing to serve');
+	}
+}

--- a/tests/Unit/IngestFeederTest.php
+++ b/tests/Unit/IngestFeederTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use XcVm\Streaming\Fanout\IngestFeeder;
+
+/**
+ * @covers \XcVm\Streaming\Fanout\IngestFeeder
+ *
+ * The PHP producers' (LLOD, loopback, delay) feed into the xc_fanout daemon —
+ * since Phase E the channel's only delivery path. A socket pair stands in for the
+ * daemon's ingest socket; registration and dialing are injected.
+ */
+final class IngestFeederTest extends TestCase {
+
+	private const P = 188;
+
+	/** @var resource[] */
+	private array $open = [];
+
+	protected function tearDown(): void {
+		foreach ($this->open as $rSocket) {
+			if (is_resource($rSocket)) {
+				@fclose($rSocket);
+			}
+		}
+		$this->open = [];
+	}
+
+	/** A connected socket pair: [the feeder's end, the "daemon's" end]. */
+	private function pair(): array {
+		$rPair = stream_socket_pair(PHP_OS_FAMILY === 'Windows' ? STREAM_PF_INET : STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+		$this->assertIsArray($rPair, 'socket pair');
+		$this->open = array_merge($this->open, $rPair);
+		return $rPair;
+	}
+
+	/** $n TS packets whose bodies number them, so order and loss are visible. */
+	private function packets(int $n, int $from = 0): string {
+		$rOut = '';
+		for ($i = $from; $i < $from + $n; $i++) {
+			$rOut .= "\x47" . str_pad(pack('N', $i), self::P - 1, "\xff");
+		}
+		return $rOut;
+	}
+
+	/**
+	 * A feeder whose "daemon" is the given socket on the first dial (a fresh pair
+	 * on any redial, as a restarted daemon would give); counts registrations.
+	 */
+	private function feeder($rSocket, int &$rRegistrations, ?string $rKey = null, ?string $rIV = null, array &$rSeen = []): IngestFeeder {
+		$rFirst = true;
+		return new IngestFeeder(
+			7,
+			$rKey,
+			$rIV,
+			null,
+			function (int $rID, ?string $rK, ?string $rV) use (&$rRegistrations, &$rSeen) {
+				$rRegistrations++;
+				$rSeen = [$rID, $rK, $rV];
+				return '/run/ingest/7.sock';
+			},
+			function (string $rPath) use ($rSocket, &$rFirst) {
+				if ($rFirst) {
+					$rFirst = false;
+					return $rSocket;
+				}
+				return $this->pair()[0];
+			}
+		);
+	}
+
+	private function drain($rPeer, int $rBytes, IngestFeeder $rFeeder): string {
+		stream_set_blocking($rPeer, false);
+		$rGot = '';
+		$rDeadline = microtime(true) + 10;
+		while (strlen($rGot) < $rBytes && microtime(true) < $rDeadline) {
+			$rFeeder->flush();
+			$rChunk = fread($rPeer, 65536);
+			if ($rChunk !== false && $rChunk !== '') {
+				$rGot .= $rChunk;
+			} else {
+				usleep(1000);
+			}
+		}
+		return $rGot;
+	}
+
+	public function testRegistersWithTheStreamKeyAndDeliversEveryPacket(): void {
+		[$rMine, $rDaemon] = $this->pair();
+		$rRegs = 0;
+		$rSeen = [];
+		$rFeeder = $this->feeder($rMine, $rRegs, 'aa', 'bb', $rSeen);
+
+		$this->assertTrue($rFeeder->connect());
+		$this->assertSame([7, 'aa', 'bb'], $rSeen, 'the HLS key travels with the registration');
+
+		$rData = $this->packets(50);
+		$rFeeder->write($rData);
+		$this->assertSame($rData, $this->drain($rDaemon, strlen($rData), $rFeeder));
+		$this->assertSame(1, $rRegs);
+	}
+
+	/** A full socket must not lose or tear data: the rest waits and goes next. */
+	public function testBackpressureKeepsEveryByteInOrder(): void {
+		[$rMine, $rDaemon] = $this->pair();
+		$rRegs = 0;
+		$rFeeder = $this->feeder($rMine, $rRegs);
+		$rFeeder->connect();
+
+		$rAll = '';
+		for ($i = 0; $i < 40; $i++) { // ~3 MB — far more than a socket buffer holds
+			$rChunk = $this->packets(400, $i * 400);
+			$rAll .= $rChunk;
+			$rFeeder->write($rChunk);
+		}
+		$this->assertGreaterThan(0, $rFeeder->backlog(), 'the socket filled, so some of it waited');
+
+		$rGot = $this->drain($rDaemon, strlen($rAll), $rFeeder);
+		$this->assertSame(strlen($rAll), strlen($rGot));
+		$this->assertTrue($rGot === $rAll, 'identical bytes, in order');
+		$this->assertSame(0, $rFeeder->backlog());
+	}
+
+	/** After a failure the half-sent packet's tail is discarded, so the next connection starts aligned. */
+	public function testReconnectStartsOnAPacketBoundary(): void {
+		[$rMine, $rDaemon] = $this->pair();
+		$rRegs = 0;
+		$rFeeder = $this->feeder($rMine, $rRegs);
+		$rFeeder->connect();
+
+		$rRef = new ReflectionClass($rFeeder);
+		$rRef->getProperty('pending')->setValue($rFeeder, substr($this->packets(3), 100)); // head packet 100 bytes in
+		$rRef->getProperty('headSent')->setValue($rFeeder, 100);
+		$rDrop = $rRef->getMethod('drop');
+		$rDrop->invoke($rFeeder, 'test');
+
+		$this->assertFalse($rFeeder->isConnected());
+		$this->assertSame(2 * self::P, $rFeeder->backlog(), 'only whole packets remain');
+		$this->assertSame("\x47", substr((string) $rRef->getProperty('pending')->getValue($rFeeder), 0, 1));
+
+		// Within the backoff nothing is redialled; after it, the ingest is registered again.
+		$rFeeder->flush();
+		$this->assertSame(1, $rRegs);
+		$rRef->getProperty('retryAt')->setValue($rFeeder, 0.0);
+		$rFeeder->flush();
+		$this->assertSame(2, $rRegs, 're-registered (a restarted daemon hands out a fresh socket)');
+		$this->assertTrue($rFeeder->isConnected());
+		$this->assertSame(0, $rFeeder->backlog(), 'the aligned remainder went to the new connection');
+	}
+
+	/** With the daemon away the backlog is capped by shedding the OLDEST whole packets. */
+	public function testOverflowShedsTheOldestWholePackets(): void {
+		$rFeeder = new IngestFeeder(7, null, null, null, fn() => null, fn() => false);
+		$rTotal = 0;
+		$rLast = '';
+		for ($i = 0; $i < 50; $i++) { // 50 × ~188 KB ≈ 9.4 MB > the 8 MB ceiling
+			$rLast = $this->packets(1000, $i * 1000);
+			$rTotal += strlen($rLast);
+			$rFeeder->write($rLast);
+		}
+		$this->assertLessThanOrEqual(8388608, $rFeeder->backlog());
+		$this->assertSame(0, $rFeeder->backlog() % self::P, 'whole packets only');
+		$this->assertSame($rTotal - $rFeeder->backlog(), $rFeeder->droppedPackets() * self::P);
+
+		$rRef = new ReflectionClass($rFeeder);
+		$rPending = (string) $rRef->getProperty('pending')->getValue($rFeeder);
+		$this->assertSame($rLast, substr($rPending, -strlen($rLast)), 'the newest data is what is kept');
+	}
+
+	public function testStreamKeyReadsTheLaunchersKeyFiles(): void {
+		if (!defined('STREAMS_PATH')) {
+			define('STREAMS_PATH', sys_get_temp_dir() . '/xcvm-feeder-test/');
+		}
+		if (!is_dir(STREAMS_PATH)) {
+			mkdir(STREAMS_PATH, 0777, true);
+		}
+		$rID = 990000 + random_int(0, 9999);
+		file_put_contents(STREAMS_PATH . $rID . '_.key', str_repeat("\x01", 16));
+		file_put_contents(STREAMS_PATH . $rID . '_.iv', str_repeat("\x02", 16));
+		try {
+			$this->assertSame([str_repeat('01', 16), str_repeat('02', 16)], IngestFeeder::streamKey($rID));
+			$this->assertSame([null, null], IngestFeeder::streamKey($rID + 1), 'no files, no key');
+		} finally {
+			@unlink(STREAMS_PATH . $rID . '_.key');
+			@unlink(STREAMS_PATH . $rID . '_.iv');
+		}
+	}
+}

--- a/tests/Unit/MonitorCommandTest.php
+++ b/tests/Unit/MonitorCommandTest.php
@@ -120,4 +120,31 @@ final class MonitorCommandTest extends TestCase {
 		[, $seg2] = $this->call('persistSegmentDuration', ['of_duration' => 6], 4243, 8);
 		$this->assertSame(8, $seg2, 'segTime kept (already larger)');
 	}
+
+	// ── FPS-drop restart ───────────────────────────────────────
+
+	public function testFpsThresholdIsAPercentageOfTheBaseline(): void {
+		// 90% of 25 fps = 22.5: 22 is a drop, 23 is not.
+		$this->assertTrue(MonitorCommand::isFpsBelowThreshold(22.0, 25.0, 90));
+		$this->assertFalse(MonitorCommand::isFpsBelowThreshold(23.0, 25.0, 90));
+		// The old formula (fps * 90 < baseline) only fired below ~0.28 fps here.
+		$this->assertTrue(MonitorCommand::isFpsBelowThreshold(12.5, 25.0, 90));
+	}
+
+	public function testFpsThresholdDefaultsTo90AndIsClamped(): void {
+		$this->assertTrue(MonitorCommand::isFpsBelowThreshold(22.0, 25.0, 0), 'unset → 90%');
+		$this->assertFalse(MonitorCommand::isFpsBelowThreshold(23.0, 25.0, ''), 'unset → 90%');
+		$this->assertFalse(MonitorCommand::isFpsBelowThreshold(25.0, 25.0, 250), 'clamped to 100%');
+		$this->assertFalse(MonitorCommand::isFpsBelowThreshold(10.0, 0.0, 90), 'no baseline, no restart');
+	}
+
+	// ── priority backup ────────────────────────────────────────
+
+	public function testPriorityBackupOnlyConsidersHigherRankedSources(): void {
+		$sources = ['A', 'B', 'C'];
+		$this->assertSame(['A'], MonitorCommand::higherPrioritySources($sources, 'B'), 'from B only A, never C');
+		$this->assertSame(['A', 'B'], MonitorCommand::higherPrioritySources($sources, 'C'));
+		$this->assertSame([], MonitorCommand::higherPrioritySources($sources, 'A'), 'on the primary: nothing to switch back to');
+		$this->assertSame($sources, MonitorCommand::higherPrioritySources($sources, 'X'), 'unknown current: all are candidates');
+	}
 }

--- a/tests/Unit/StreamProcessBuildLiveTest.php
+++ b/tests/Unit/StreamProcessBuildLiveTest.php
@@ -139,9 +139,38 @@ final class StreamProcessBuildLiveTest extends TestCase {
 		$this->assertStringContainsString('-map 0 -copy_unknown', $out);
 	}
 
-	/** The legacy path registers no ingest for loopback and must stay on-disk only. */
-	public function testLegacyLoopbackStaysOnDiskOnly(): void {
+	/** With no daemon ingest (daemon unreachable) a loopback stays on-disk only. */
+	public function testLoopbackWithoutIngestStaysOnDiskOnly(): void {
 		$this->assertStringNotContainsString('-f tee', $this->build(['loopback' => true]));
+	}
+
+	/** A self-launched (unsupervised) loopback feeds the daemon too — clients are daemon-only. */
+	public function testUnsupervisedLoopbackTeesIntoTheDaemon(): void {
+		$out = $this->build(['loopback' => true, 'ingestSock' => '/run/ingest/42.sock']);
+		$this->assertStringContainsString('-f tee', $out);
+		$this->assertStringContainsString('unix:/run/ingest/42.sock', $out);
+	}
+
+	// ── LLOD ───────────────────────────────────────────────────
+
+	/** +nobuffer is a demuxer flag: it belongs before -i, not among the output options. */
+	public function testLlodLatencyFlagsSitOnTheInput(): void {
+		$out = $this->build(['llod' => true]);
+		$input = substr($out, 0, (int) strpos($out, ' -i '));
+		$this->assertStringContainsString('-fflags +discardcorrupt+nobuffer', $input);
+		$this->assertStringNotContainsString('-fflags nobuffer', $out);
+	}
+
+	/** A stream copy gets no encoder tune; x264 gets zerolatency; NVENC its own option. */
+	public function testLlodTuneMatchesTheEncoder(): void {
+		$this->assertStringNotContainsString('-tune', $this->build(['llod' => true]));
+
+		$x264 = $this->build(['llod' => true, 'stream_info' => ['enable_transcode' => 1, 'transcode_profile_id' => 1, 'profile_options' => json_encode(['-vcodec' => 'libx264'])]]);
+		$this->assertStringContainsString('-tune zerolatency', $x264);
+
+		$nvenc = $this->build(['llod' => true, 'stream_info' => ['enable_transcode' => 1, 'transcode_profile_id' => 1, 'profile_options' => json_encode(['-vcodec' => 'h264_nvenc'])]]);
+		$this->assertStringNotContainsString('-tune zerolatency', $nvenc, 'NVENC rejects the x264 tune value');
+		$this->assertStringContainsString('-zerolatency 1', $nvenc);
 	}
 
 	// ── custom_ffmpeg branch ───────────────────────────────────

--- a/tests/Unit/StreamProcessSubtitleTest.php
+++ b/tests/Unit/StreamProcessSubtitleTest.php
@@ -96,4 +96,26 @@ final class StreamProcessSubtitleTest extends TestCase {
 		$this->assertStringContainsString('action=getFile', $import);
 		$this->assertStringContainsString('filename=', $import);
 	}
+
+	/**
+	 * The remote filename is URL-encoded from the raw path — not from the shell-
+	 * quoted one, which put encoded quotes (%27) into the name the remote server
+	 * looked up.
+	 */
+	public function testRemoteSubtitleFilenameCarriesNoShellQuotes(): void {
+		if (PHP_OS_FAMILY === 'Windows') {
+			$this->markTestSkipped('escapeshellarg() rewrites % on Windows; the panel runs on Linux');
+		}
+		$servers = [2 => ['api_url' => 'http://node2/api?key=abc']];
+		$json = json_encode([
+			'location' => 2,
+			'files'    => ['/subs/My Movie.srt'],
+			'charset'  => ['UTF-8'],
+			'names'    => ['Remote'],
+		]);
+		[$import] = $this->build($json, $servers);
+
+		$this->assertStringContainsString('filename=' . urlencode('/subs/My Movie.srt'), $import);
+		$this->assertStringNotContainsString('%27', $import);
+	}
 }


### PR DESCRIPTION

Fixes from a review of the streaming code (delivery, on-demand, LLOD). The main theme: since ADR 0003 Phase E the xc_fanout daemon is the only client delivery path, and several producers and control paths hadn't caught up with that.

Broken for users before this PR
Delayed channels (delay_minutes > 0) couldn't be watched at all. Nothing fed the daemon the delayed stream: the tee is skipped for delay, the supervisor refuses delay streams, and DelayCommand never registered an ingest. DelayCommand now pushes each delayed segment into the daemon as it publishes it, paced over the segment's duration.
Connection limits and admin kicks didn't disconnect daemon-served TS viewers. Their rows have pid = 0, so there was nothing to kill; the row was deleted and the viewer kept streaming, untracked. Kicks now go through the daemon's new DELETE /connections/<uuid> (https://github.com/obscuremind/XC_VM_Fanout/pull/3):
directly when the viewer is on this node, or as a drop_con signal to the node serving it;
fanout_sync also drops daemon viewers whose row is gone;
the limiter no longer evicts the requesting connection itself, which it could do now that every daemon row shares pid 0.
Encrypted HLS couldn't be decoded for loopback (LB restream) and llod=2. The playlist declares AES-128, but those producers registered without the key. Every producer now passes it.
Other fixes
Daemon feed reliability: new IngestFeeder. The LLOD, loopback and delay feeds no longer tear packets on a short non-blocking write, and they reconnect after a daemon restart instead of staying dark.
ffmpeg loopback (php_loopback off, or no supervision) never fed the daemon; it now tees.
HLS numbering: MEDIA-SEQUENCE was renumbered mid-playback for segments over 10 s, and could step backwards after a stream restart.
Catch-up:
seeking streamed from the archive's first byte;
the throttle paused one second after every chunk;
routing through a proxy used an undefined variable;
catch-up was refused whenever the live channel was down.
Byte ranges go through a shared RFC 7233 parser. Suffix ranges were fatal on PHP 8, and Accept-Ranges was malformed.
Direct-proxy VOD reads the source's headers with cURL instead of get_headers(), which fails on https under FPM.
Proxy-only servers trusted the client-set X-IP header. nginx now passes the real TCP peer as XC_PEER_ADDR.
Monitor:
FPS-drop restart never fired: the percentage wasn't divided by 100;
priority backup could switch down to a lower-priority source;
a failed on-demand probe now honours on_demand_failure_exit.
cron:streams:
the attached-restreamer subqueries lacked GROUP BY;
a stopped on-demand stream went on to spawn thumbnail and archive workers;
the daemon re-feed restart skips self-feeding producers, and its throttle stamp was being deleted by the restart itself.
LLOD:
+nobuffer moves to the input;
-tune zerolatency is used only with x264/x265, since NVENC rejected it and the start failed;
an LLOD start uses the first source instead of the last;
the segmenter honours the stream's headers, cookie, proxy and prebuffer settings;
TS sources are accepted by content;
the stale-segmenter check found the right process;
playlists are written atomically.
On-demand start:
the pid wait follows on_demand_wait_time;
stale pid and monitor files are cleared before a new start;
the "100 ms" file cache really lasted 27 h;
the inotify wait could hang.
Remote VOD subtitles URL-encoded a shell-quoted path.
Removes the dead HLSGenerator::generateHLS().
Deploy notes
Needs https://github.com/obscuremind/XC_VM_Fanout/pull/3 for kicks to take effect. Against an older daemon the drop call gets a 404 and does nothing, so either can deploy first.
nginx.conf and lb_configs/nginx.conf gain fastcgi_param XC_PEER_ADDR $realip_remote_addr;. Until that config is live, auth falls back to the old header check.